### PR TITLE
docs: add 7 verified runtime gotchas to troubleshooting and deployment-sops

### DIFF
--- a/skills/references/deployment-sops.md
+++ b/skills/references/deployment-sops.md
@@ -19,6 +19,12 @@ Before running `catalyst deploy`, verify all of the following:
       manually. If missing, re-initialize.
 - [ ] **`functions/` directory structure** — each function has its own subdirectory with the
       handler file (`index.js`, `index.py`, or the Java main class).
+- [ ] **All function env vars are in `catalyst-config.json`, NOT the Console UI** —
+      `catalyst deploy` **overwrites the function's environment with values from
+      `catalyst-config.json` only**. Any variable set through the Console UI is silently
+      deleted on the next deploy. Store all secrets, API keys, and config in
+      `catalyst-config.json` (gitignore this file) before deploying. After every deploy,
+      spot-check Functions → [function] → Settings → Environment Variables to confirm.
 - [ ] **AppSail apps have `catalyst-config.json`** with correct `name`, `stack`, `command`,
       `memory`, and `port` fields. The `port` must match what the app actually listens on.
 - [ ] **Web client in `client/` directory** (only if using Web Client Hosting, not Slate).
@@ -126,6 +132,13 @@ What happens on failure:
      listening on the port within 10 seconds, the instance is killed.
 3. Check AppSail instance logs: AppSail → Instances → click the Logs icon → Catalyst Logs.
 4. Verify the app uses `process.env.X_ZOHO_CATALYST_LISTEN_PORT || 9000` (Node.js) for the port.
+
+### Function behaves correctly locally but fails or uses wrong config after deploy
+- **Root cause**: environment variables set through the Catalyst Console UI are deleted on
+  every `catalyst deploy`. The deploy replaces the function environment with values from
+  `catalyst-config.json` only.
+- Fix: move all env vars into `catalyst-config.json` and redeploy. Do not rely on Console-set
+  vars for any value that must survive deployments.
 
 ### Functions deployed but not behaving as expected
 - Check `catalyst.json` for correct function names and configurations.

--- a/skills/references/troubleshooting.md
+++ b/skills/references/troubleshooting.md
@@ -21,6 +21,12 @@ AppSail crashes, Circuits failures, cron problems, or API Gateway errors.
   - Functions: `catalyst deploy --only functions`
   - AppSail: `catalyst deploy appsail`
 
+### `is_deployed: false` in API responses does not indicate a problem
+`List_All_Functions` and related API/MCP responses return `"is_deployed": false` for all
+functions — including functions that are actively deployed and handling requests. This field
+does not reflect actual deployment status and should be ignored. Verify function status from
+the Catalyst console (Functions list) or by invoking the function endpoint directly.
+
 ### AppSail deployment fails or app not responding after deploy
 - **Port mismatch** — The `port` field in `catalyst-config.json` must exactly match the port
   the app listens on. Using a different port causes requests to fail.
@@ -115,6 +121,8 @@ In `node20`, the response object is a raw `http.ServerResponse`, **not** an Expr
 - **"Empty query" error** — Wrong body key. Use `{ "zcql": "SELECT ..." }` not `{ "query": "..." }`.
 - **Max rows** — ZCQL returns a maximum of 300 rows per query. Paginate with
   `LIMIT offset, count` (e.g., `LIMIT 0, 300`, then `LIMIT 300, 300`).
+- **Max columns per SELECT** — ZCQL limits `SELECT` to 20 columns per query. Use explicit column
+  names instead of `SELECT *` on tables with more than 20 columns.
 - **Case sensitivity** — Table names and column names are case-sensitive; must match the
   console exactly.
 - **String quoting** — String values in ZCQL must be in **single quotes**: `WHERE name = 'Alice'`.
@@ -152,6 +160,52 @@ Error: `"No privileges to perform this action"`
 - Data Store does NOT support emoji or 4-byte UTF-8 characters (many CJK extensions).
 - These are silently stored as `?`.
 - Workaround: store a string key (e.g., `"happy"`) and map to emoji in application code.
+
+### DataStore SDK methods hang silently in Job functions (Python SDK)
+All `zcatalyst_sdk` DataStore `Table` methods (`get_paged_rows`, `delete_rows`, `insert_rows`,
+etc.) use `CredentialUser.USER` internally. Job functions run under admin credentials only —
+`CredentialUser.USER` has no token, so every DataStore SDK call makes a request with no auth,
+waits 60 seconds, and fails silently. No exception is raised; the function eventually hits the
+15-minute hard timeout.
+- Fix: call the underlying requester directly with `CredentialUser.ADMIN`:
+  ```python
+  from zcatalyst_sdk.credential import CredentialUser
+
+  rows = table._requester.request(
+      method="GET",
+      path=f"/datastore/table/{table_identifier}/tablerow",
+      user=CredentialUser.ADMIN,
+      timeout=10,
+  )
+  ```
+- Cache SDK methods are NOT affected — they already use `CredentialUser.ADMIN` by default.
+
+---
+
+## Cache Errors
+
+### `segment.delete()` / `Delete_Cache_Item` does not remove the key
+`segment.delete(key)` (SDK) and the `Delete_Cache_Item` MCP tool both set `cache_value = null`
+and clear the TTL, but the key continues to exist indefinitely. A subsequent `segment.getValue(key)`
+does NOT raise a "key not found" error — it returns a result object with a null value. Code that
+checks for key absence by catching an exception will incorrectly treat the null-value key as
+present.
+- Fix: check the value itself, not the exception:
+  ```python
+  lock_val = segment.get_value(key)  # does not raise even if deleted
+  if lock_val:  # truthy check — null/empty means absent
+      # key is live
+  ```
+
+### `segment.update()` without TTL creates an immortal key
+`segment.update(key, value)` called without an expiry argument creates a key with no TTL that
+persists indefinitely — it will never expire, even across server restarts.
+- Fix: always pass the same TTL used at creation time:
+  ```python
+  segment.update(key, value, 1)  # 1-hour TTL, matching segment.put(key, value, 1)
+  ```
+- This applies to lock tokens, session state, and any key originally created with a TTL.
+  Updating without an expiry silently removes the expiration.
 
 ---
 
@@ -221,6 +275,20 @@ Causes (check in this order):
 - Calling it without an argument crashes because the SDK calls `.startsWith("/")` on `undefined`.
 - Fix: `catalyst.auth.signOut(window.location.origin);` (Slate apps) or `catalyst.auth.signOut(window.location.origin + '/app/index.html');` (legacy Web Client)
 - Note: `constructSignOutUrl()` does not exist — do not use a two-step pattern.
+
+### `Authorization: Bearer` header intercepted before the function handler runs
+Catalyst validates any `Authorization: Bearer <token>` header as a Zoho OAuth token **before**
+passing the request to the function handler — even when the endpoint's Security Rule has
+`authentication: optional`. If your function uses its own Bearer token for server-to-server
+auth (e.g. a shared secret), Catalyst returns `INVALID_TOKEN` before your code runs.
+- Fix: use a non-standard header for application-level secrets:
+  ```
+  # ✓ Not intercepted — use this for custom auth
+  X-My-App-Token: <secret>
+
+  # ✗ Intercepted by Catalyst's auth layer — avoid for custom secrets
+  Authorization: Bearer <secret>
+  ```
 
 ### ZAID mismatch between environments
 - ZAID (Zoho Application ID) differs between Development and Production environments.


### PR DESCRIPTION
## What this adds

Seven entries verified from real Catalyst production deployments — all of them caused
real debugging sessions because the behavior was non-obvious or undocumented.

### `troubleshooting.md`

**Deployment Failures**
- `is_deployed: false` in `List_All_Functions` / API responses is not a reliable deployment
  indicator — all functions return this value regardless of whether they are live.

**Data Store / ZCQL Errors**
- ZCQL has a **20-column `SELECT` limit** in addition to the documented 300-row limit.
  `SELECT *` on a wide table silently returns only the first 20 columns.

- **DataStore SDK methods hang silently in Job functions (Python SDK)** — `zcatalyst_sdk`
  `Table` methods (`get_paged_rows`, `delete_rows`, `insert_rows`, etc.) use
  `CredentialUser.USER` internally. Job functions have no USER token, so every call
  makes an unauthenticated request, waits 60 seconds per attempt, and raises no exception.
  The function silently burns toward the 15-minute timeout. Fix: call the underlying
  `_requester` with `CredentialUser.ADMIN` directly.

**Cache Errors** (new section)
- `segment.delete()` / `Delete_Cache_Item` clears `cache_value` to null but the **key
  persists indefinitely** with no TTL. `getValue()` does not raise on a deleted key — it
  returns a null-value result. Code checking for absence by catching an exception will
  incorrectly treat the key as present. Fix: truthy-check the value, not the exception.

- `segment.update(key, value)` without an expiry argument creates an **immortal key** — no
  TTL, never expires. Any key originally created with a TTL must be updated with the same
  TTL to preserve expiration behavior.

**Auth Errors**
- `Authorization: Bearer <token>` is **intercepted and validated by Catalyst as a Zoho OAuth
  token before the function handler runs** — even when `authentication: optional` is set on
  the Security Rule. Server-to-server secrets using the `Authorization` header get rejected
  with `INVALID_TOKEN` before your code runs. Fix: use a non-standard header
  (e.g. `X-My-App-Token`) for application-level secrets.

---

### `deployment-sops.md`

- **`catalyst deploy` silently deletes all Console-set environment variables.** Only values
  in `catalyst-config.json` survive a deploy. This is the #1 cause of "works in dev,
  breaks after deploy" bugs. Added as a pre-deploy checklist item and as a dedicated
  recovery entry under common failures.

---

All entries follow the existing format (bullet points, `**bold**` keyword + em dash, Fix:
prefix, code blocks where the pattern matters). No existing content was changed.