### PR TITLE
fix: cross-domain auth, CORS gateway ownership, token path, scope gui…

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "catalyst-by-zoho",
+  "description": "Official plugin for Catalyst by Zoho — AI agent skills for the full-stack serverless cloud platform.",
   "owner": {
     "name": "Catalyst by Zoho",
     "email": "support@zohocatalyst.com"

--- a/skills/references/architecture-patterns.md
+++ b/skills/references/architecture-patterns.md
@@ -128,10 +128,11 @@ Auth: Catalyst Auth & User Management
 **Services:** Slate · Advanced I/O Function · Data Store · Stratus · Auth
 
 **Key implementation notes:**
-- Always use `credentials: 'include'` in `fetch()` calls from Slate to the function
+- **Same-domain (legacy Web Client):** Use `credentials: 'include'` in `fetch()` calls
+- **Cross-domain (Slate → Serverless Function):** Use `generateAuthToken()` with the full function URL and `Authorization: ${token}` header. Add Slate domain to Authorized Domains in console with CORS toggle enabled. Do NOT use Express `cors()` middleware — the gateway handles CORS headers for production origins.
 - **⚠️ REQUIRED: Enable App User permissions on every table** — Console → Data Store → {Table} → Scopes & Permissions → App User → check Select, Insert, Update, Delete. Without this, ALL user-authenticated operations fail silently. This is not optional.
-- Use admin-scoped SDK (`catalyst.initialize(req, { scope: 'admin' })`) for DataStore operations to bypass user permission checks
-- Use user-scoped SDK only to call `getCurrentUser()` for auth verification
+- Use admin-scoped SDK (`catalyst.initialize(req, { scope: 'admin' })`) for DataStore/Stratus/ZCQL operations
+- Use user-scoped SDK (`catalyst.initialize(req)`) ONLY for `getCurrentUser()` for auth verification — admin scope cannot resolve user identity
 
 **Project structure:**
 ```
@@ -428,6 +429,7 @@ When a user describes their use case, follow this process:
 
 5. **Flag common gotchas** relevant to the architecture:
    - DataStore → remind to enable CRUD permissions for App User role
-   - Web client → function calls → remind about `credentials: 'include'`
+   - Web client → function calls → remind about `credentials: 'include'` (same-domain) or `generateAuthToken()` (cross-domain from Slate)
+   - Slate + Functions → remind: gateway owns CORS headers, no Express `cors()` middleware
    - AppSail → remind about the correct port env variable
    - Job Scheduling → note that CLI always deploys to Development

--- a/skills/references/deployment-sops.md
+++ b/skills/references/deployment-sops.md
@@ -153,6 +153,72 @@ What happens on failure:
    timeouts, and exceptions from DevOps → Application Alerts.
 6. **User limit**: Development supports max 25 users; Production has no user limit.
 
+### Function promotion to Production (separate step)
+
+`catalyst deploy --only functions` deploys to the **Development** environment only.
+Promoting functions to Production requires a **separate manual step** in the console:
+
+> Console → Cloud Scale → Serverless → Deploy → Select Functions → Initiate Deployment
+
+If this step is skipped, the Development function has your latest code but Production still
+runs old code. The Diff Generation screen will show `Total Changes: 0` for Functions if
+there are no new changes to promote — use this as a diagnostic.
+
+### Slate production deployment
+
+Slate can be deployed directly to production from the CLI:
+```bash
+catalyst deploy slate --production
+```
+
+### Recommended: deploy components separately
+
+Deploy functions and Slate separately rather than using `catalyst deploy` (which deploys everything):
+```bash
+# Deploy function changes
+catalyst deploy --only functions
+
+# Deploy frontend changes
+catalyst deploy slate
+```
+
+This gives clearer error messages, avoids deploying unchanged components, and makes it
+easier to diagnose which component caused a failure.
+
+---
+
+## Slate-specific deployment gotchas
+
+### `slate-config.toml` wiped by clean builds
+
+The `.catalyst/slate-config.toml` file lives inside the build output directory (e.g., `dist/`).
+Any build command that cleans the output (Vite `--clean`, Expo `--clear`, `rm -rf dist/`) deletes
+this file. Without it, `catalyst deploy slate` fails.
+
+**Fix — recreate after every clean build:**
+```bash
+# Vite/React example
+npm run build && mkdir -p dist/.catalyst && \
+  echo -e 'framework = "static"\ndeployment_name = "default"' > dist/.catalyst/slate-config.toml
+
+# Expo web example
+npx expo export --platform web --clear && \
+  mkdir -p dist/.catalyst && \
+  echo -e 'framework = "static"\ndeployment_name = "default"' > dist/.catalyst/slate-config.toml
+
+# Then deploy
+catalyst deploy slate
+```
+
+### `baseUrl` breaks assets on Slate
+
+If your build config has a `baseUrl` or `basePath` set to a sub-path (e.g., `/server/my_function`
+for serving from inside a function), all JS/CSS URLs will be prefixed with that path on Slate.
+Since Slate serves from root `/`, every asset returns 404.
+
+**Fix:** Remove `baseUrl`/`basePath` from your build config before building for Slate. Only set
+it when the frontend is served from inside a function or AppSail sub-path.
+
 ---
 
 ## `catalyst-config.json` reference (AppSail)

--- a/skills/references/functions-and-sdk.md
+++ b/skills/references/functions-and-sdk.md
@@ -208,6 +208,84 @@ module.exports = async (req, res) => {
 
 Invocation: Any HTTP method to `/server/my_api/execute`
 
+### User-scope vs admin-scope initialization
+
+The SDK supports two initialization scopes. Choose based on what the operation needs:
+
+```javascript
+// USER SCOPE (default) — for resolving user identity
+const userApp = catalyst.initialize(req);
+const currentUser = await userApp.userManagement().getCurrentUser();
+// getCurrentUser() makes an internal GET to /project-user/current using the user token.
+// Only works for registered app users (signed up via Catalyst auth), NOT collaborators/admins.
+
+// ADMIN SCOPE — for all data operations (DataStore, Stratus, ZCQL, Cache, etc.)
+const adminApp = catalyst.initialize(req, { scope: 'admin' });
+const dataStore = adminApp.datastore();
+const zcql = adminApp.zcql();
+const stratus = adminApp.stratus();
+```
+
+**Common pattern for apps that need both auth AND data:**
+```javascript
+module.exports = async (req, res) => {
+  try {
+    // 1. Get user identity (user-scope)
+    const userApp = catalyst.initialize(req);
+    const currentUser = await userApp.userManagement().getCurrentUser();
+    
+    // 2. Perform data operations (admin-scope)
+    const adminApp = catalyst.initialize(req, { scope: 'admin' });
+    const table = adminApp.datastore().table('MyTable');
+    
+    // 3. Use currentUser for ownership/filtering
+    const rows = await adminApp.zcql().executeZCQLQuery(
+      `SELECT * FROM MyTable WHERE owner_id = '${currentUser.user_id}'`
+    );
+    sendJson(res, 200, { user: currentUser, data: rows });
+  } catch (error) {
+    sendJson(res, 500, { error: error.message });
+  }
+};
+```
+
+> ⚠️ **Do NOT use admin-scope for `getCurrentUser()`** — it throws "no user credentials present".
+> Admin scope lacks user identity. Use default (user) scope for identity, admin scope for data.
+
+### CORS handling for Slate → Function cross-domain
+
+When a Slate frontend calls your Advanced I/O function cross-domain, the Catalyst gateway injects
+`Access-Control-Allow-Origin` automatically (if the Slate domain is in Authorized Domains in the console).
+
+**Critical rule: do NOT set CORS headers in your function for production origins.** If both the
+gateway and your code set `Access-Control-Allow-Origin`, the browser receives duplicate values
+and rejects the response.
+
+Only set CORS headers for `localhost` (local dev, where no gateway exists):
+
+```javascript
+// Place this BEFORE your route handlers
+app.use((req, res, next) => {
+  const origin = req.headers.origin || '';
+  if (/^http:\/\/localhost(:\d+)?$/.test(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    if (req.method === 'OPTIONS') return res.status(204).end();
+  }
+  next();
+});
+```
+
+**Setup required in the console:**
+Console → Authentication → Whitelisting → Authorized Domains → add your Slate domain → enable CORS toggle.
+
+> ⚠️ **The `Authorization` header your frontend sends is stripped by the gateway.** After
+> validation, the gateway replaces it with internal `x-zc-*` headers. `req.headers['authorization']`
+> will be `undefined` inside your function. The SDK reads the `x-zc-*` headers internally via
+> `catalyst.initialize(req)` — you don't need to handle this manually.
+
 ### HTTP payload limits
 
 | Limit | Value |
@@ -836,6 +914,10 @@ function code, especially when switching between function types or languages.
 | Using wrong port variable for AppSail | App binds to hard-coded port; Catalyst routes to a different port, causing connection failures | Always use `process.env.X_ZOHO_CATALYST_LISTEN_PORT \|\| 9000` |
 | Not adding `credentials: 'include'` to fetch calls from web client | Auth cookies not forwarded; `getCurrentUser()` throws 401 even for authenticated users | Add `credentials: 'include'` to all fetch calls from the web client |
 | Parsing `CREATEDTIME` directly with `new Date()` | Catalyst stores CREATEDTIME in the project timezone without an offset marker; `new Date()` treats it as UTC → wrong timestamps | Append the project timezone offset before parsing the date string |
+| Using Express `cors()` middleware with Slate → Function cross-domain | Gateway AND Express both inject `Access-Control-Allow-Origin` → duplicate header → browser rejects | Only set CORS headers for localhost (local dev). Remove `cors()` middleware entirely for production origins. The gateway handles it. |
+| Using admin-scope for `getCurrentUser()` | Throws "no user credentials present" — admin scope has no user identity | Use default (user) scope: `catalyst.initialize(req)` for `getCurrentUser()`. Use admin scope only for data operations. |
+| Not handling `getCurrentUser()` returning `null` | Collaborators/admins are not registered app users → `null` return → `Cannot read properties of null` | Add null check. `getCurrentUser()` only works for users who signed up through Catalyst's auth flow, not console collaborators. |
+| Reading `req.headers['authorization']` inside the function | Gateway strips the `Authorization` header after validation and injects `x-zc-*` internal headers instead → `undefined` | Don't read the Authorization header. Use `catalyst.initialize(req)` which reads the `x-zc-*` headers internally. |
 
 ### Java
 

--- a/skills/references/sdk-web.md
+++ b/skills/references/sdk-web.md
@@ -176,12 +176,14 @@ catalyst.auth.signOut(redirectURL);
 
 ### generateAuthToken() (v4.6.1+)
 
-Generate a short-lived auth token for cross-domain requests (e.g., calling AppSail from a Slate widget):
+Generate a short-lived auth token for cross-domain requests (e.g., calling Serverless Functions or AppSail from a Slate app):
 
 ```js
 const tokenResponse = await catalyst.auth.generateAuthToken();
-const token = tokenResponse.content.token;
+const token = tokenResponse.access_token;
 ```
+
+> ⚠️ **The token is at `tokenResponse.access_token`** — NOT `tokenResponse.content.token`. This method does NOT follow the standard `{status, content, message}` response pattern used by other SDK methods.
 
 ### JWT Sign-In
 
@@ -203,20 +205,20 @@ await catalyst.auth.signinWithJwt(jwtToken);
 
 ### Calling AppSail from Slate (Cross-Domain Pattern)
 
-When calling an AppSail endpoint from a Slate widget, you need to pass an auth token since they are on different subdomains.
+When calling an AppSail endpoint from a Slate app, you need to pass an auth token since they are on different subdomains.
 
 **Helper function:**
 
 ```js
 async function callAppSail(endpoint, method = "GET", body = null) {
   const tokenResponse = await catalyst.auth.generateAuthToken();
-  const token = tokenResponse.content.token;
+  const token = tokenResponse.access_token;
 
   const options = {
     method: method,
     headers: {
       "Content-Type": "application/json",
-      "Authorization": `Zoho-catalyst-appsail ${token}`
+      "Authorization": token   // Raw token — no prefix needed
     }
   };
 
@@ -238,8 +240,8 @@ const result = await callAppSail("/api/items", "POST", { name: "New Item" });
 
 **Required configuration:**
 
-- **AppSail CORS whitelist:** Add your Slate domain (`*.catalystserverless.com`) in the AppSail CORS settings via the Catalyst console
-- **No `cors()` middleware:** Do NOT add Express `cors()` middleware in your AppSail code — Catalyst handles CORS at the platform level. Adding middleware causes duplicate header errors.
+- **Authorized Domains:** Add your Slate domain in Console → Authentication → Authorized Domains → enable CORS toggle. The Catalyst gateway will inject `Access-Control-Allow-Origin` automatically.
+- **No `cors()` middleware:** Do NOT add Express `cors()` middleware in your backend code — Catalyst's gateway handles CORS at the platform level. Adding middleware causes **duplicate `Access-Control-Allow-Origin` headers**, which browsers reject.
 
 ### ⚠️ Calling Advanced I/O Functions from Slate (Cross-Domain — Required)
 
@@ -256,35 +258,70 @@ Slate apps are served from `*.onslate.com`. Advanced I/O functions are on `*.cat
 // Build the full function URL (NOT a relative path)
 const FUNCTION_URL = 'https://{project-domain}.development.catalystserverless.com/server/{function_name}/execute';
 
-async function callFunction(params = {}) {
+async function callFunction(path, method = 'GET', body = null) {
   // Get short-lived auth token from the Web SDK
   const tokenRes = await window.catalyst.auth.generateAuthToken();
-  const token = tokenRes.content.token;
+  const token = tokenRes.access_token;  // NOT .content.token
 
-  const url = new URL(FUNCTION_URL);
-  // Add query params if needed
-  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
-
-  const res = await fetch(url.toString(), {
-    method: 'GET', // or 'POST' with body
+  const options = {
+    method,
     headers: {
-      'Authorization': `Zoho-catalyst-appsail ${token}`,
+      'Authorization': token,  // Raw token — no prefix needed
       'Content-Type': 'application/json'
     }
-  });
+  };
+
+  if (body && method !== 'GET' && method !== 'HEAD') {
+    options.body = JSON.stringify(body);
+  }
+
+  const url = path.startsWith('http') ? path : `${FUNCTION_URL}${path}`;
+  const res = await fetch(url, options);
   return res.json();
 }
 ```
 
-**Required console setup — CORS whitelist:**
+**Required console setup — Authorized Domains:**
 
-Go to **Catalyst Console → Authentication → Authorized Domains (CORS)** and add both domains:
-- `https://{your-app}.onslate.com` (your Slate frontend)
-- `https://{project-domain}.development.catalystserverless.com` (your functions)
+Go to **Catalyst Console → Authentication → Whitelisting → Authorized Domains** and add your Slate domain:
+- Add `{your-app}.onslate.com` → enable the **CORS** toggle
 
-Without this, the browser blocks the cross-domain fetch entirely.
+The Catalyst gateway will inject `Access-Control-Allow-Origin: https://{your-app}.onslate.com` on every response from your function. **Do NOT also set CORS headers in your function code** — duplicating the header causes browsers to reject the response.
 
 > **Tip:** The `{project-domain}` is in `.catalystrc` → `project_domain`. Example: `myapp-60019947973.development.catalystserverless.com`.
+
+**What happens under the hood (the gateway flow):**
+
+```
+1. Frontend: generateAuthToken() → gets access_token → sends as Authorization header
+2. Catalyst Gateway: validates token → strips Authorization → injects internal headers:
+   - x-zc-user-cred-type, x-zc-user-cred-token, x-zc-user-type (user identity)
+   - x-zc-admin-cred-type, x-zc-admin-cred-token (admin credentials)
+   - x-zc-projectid, x-zc-project-key, x-zc-environment (project context)
+   Also injects: Access-Control-Allow-Origin (from Authorized Domains config)
+3. Function: catalyst.initialize(req) reads the x-zc-* headers directly from req.headers
+4. Function: userManagement().getCurrentUser() makes internal API call using the user token
+```
+
+> ⚠️ **The `Authorization` header your frontend sends is NOT available in `req.headers` inside the function.** The gateway strips it after validation. The SDK reads the injected `x-zc-*` headers instead. Do not try to read `req.headers['authorization']` — it will be `undefined`.
+
+**CORS rule for functions with Express (e.g., Advanced I/O with Express router):**
+
+The gateway owns CORS headers for all production/deployed origins. Your Express code should only handle CORS for localhost (local dev, where no gateway exists):
+
+```js
+app.use((req, res, next) => {
+  const origin = req.headers.origin || '';
+  if (/^http:\/\/localhost(:\d+)?$/.test(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    if (req.method === 'OPTIONS') return res.status(204).end();
+  }
+  next();
+});
+```
 
 ---
 
@@ -461,7 +498,7 @@ const allVars = await env.getAll();
 | `isUserAuthenticated` fails locally           | SDK version below v4.5.0                                   | Upgrade to v4.5.0+                                                                          |
 | `generateAuthToken is not a function`         | SDK version below v4.6.1                                   | Upgrade to v4.6.1+                                                                          |
 | `NO_ACCESS` on API calls                      | User role lacks permission for the resource                | Check role permissions in Catalyst console                                                   |
-| Duplicate CORS headers / preflight fails      | Express `cors()` middleware AND Catalyst CORS both active   | Remove `cors()` middleware from AppSail code; configure CORS only in Catalyst console        |
+| Duplicate CORS headers / preflight fails      | Express `cors()` middleware AND Catalyst Authorized Domains both inject `Access-Control-Allow-Origin` | Remove ALL Express CORS headers for production origins. Only set CORS for localhost (local dev). The gateway owns CORS for deployed origins. |
 | Sign-out not working / crashes                 | `signOut()` called without redirect URL argument           | Pass a redirect URL: `catalyst.auth.signOut(redirectURL)`. `constructSignOutUrl()` does not exist. |
 | `getCurrentUser is not a function`             | Method does not exist in Web SDK                           | Use `catalyst.auth.isUserAuthenticated()` — resolves with full user object                    |
 | Embedded iFrame won't load                    | Div ID mismatch or CSP blocking                            | Verify the div `id` matches, check Content-Security-Policy headers allow Zoho iFrame origins |

--- a/skills/references/services.md
+++ b/skills/references/services.md
@@ -136,11 +136,10 @@ This applies to all env vars including secrets, API keys, and table names. Do no
 Note: For serverless Functions, `env_variables` in `catalyst-config.json` DO work and are
 deployed with the function. This limitation is specific to AppSail.
 
-### AppSail + Slate cross-origin issue (development)
+### Slate + AppSail cross-origin issue
 
-In Catalyst development environments, the authentication layer blocks direct browser requests
-from other origins. A Slate-hosted frontend calling AppSail APIs will get `"Unable to Fetch"`
-or `"Failed to fetch"` errors — this is NOT a CORS configuration issue, it's Catalyst's auth layer.
+A Slate-hosted frontend calling AppSail APIs may get `"Unable to Fetch"` or `"Failed to fetch"`
+errors due to Catalyst's auth layer on AppSail.
 
 **Solution — serve the frontend from AppSail itself (same-origin):**
 
@@ -164,6 +163,51 @@ app.get('*', (req, res) => {
 Copy your frontend build output into `public/` inside the AppSail directory. Use relative
 URLs in frontend code (`const API_BASE = ''`) so all API calls stay same-origin.
 This eliminates both CORS and auth-layer issues without extra configuration.
+
+### Slate + Serverless Functions cross-origin (WORKS — with correct setup)
+
+Unlike AppSail, **Slate → Serverless Function cross-domain requests DO work** once configured correctly.
+The Catalyst ZGS gateway handles CORS injection automatically.
+
+**Required setup:**
+
+1. **Add Slate domain to Authorized Domains** — Console → Authentication → Whitelisting →
+   Authorized Domains → + Add Domain → add your Slate URL (e.g. `myapp.onslate.com`) → enable CORS toggle.
+   This makes the gateway inject `Access-Control-Allow-Origin` on every response.
+
+2. **Do NOT set CORS headers in your function code for production origins.** The gateway already
+   injects them. If your Express code also sets `Access-Control-Allow-Origin`, the browser receives
+   **duplicate headers** and rejects the response:
+   ```
+   The 'Access-Control-Allow-Origin' header contains multiple values
+   'https://myapp.onslate.com, https://myapp.onslate.com', but only one is allowed.
+   ```
+
+3. **Only set CORS headers for localhost** (local dev — where no gateway is present):
+   ```javascript
+   // CORS for local development only — gateway handles production origins
+   app.use((req, res, next) => {
+     const origin = req.headers.origin || '';
+     if (/^http:\/\/localhost(:\d+)?$/.test(origin)) {
+       res.setHeader('Access-Control-Allow-Origin', origin);
+       res.setHeader('Access-Control-Allow-Credentials', 'true');
+       res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+       res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+       if (req.method === 'OPTIONS') return res.status(204).end();
+     }
+     next();
+   });
+   ```
+
+4. **Use `generateAuthToken()` with the full function URL** — relative paths resolve to
+   `onslate.com/server/...` (404). See `sdk-web.md` for the complete cross-domain pattern.
+
+**Key rule: the gateway owns CORS headers for production origins. Express must not touch them.**
+
+**What causes failures:**
+- `cors()` middleware with explicit allowed list → gateway AND Express both set the header → duplicate → rejected
+- `cors({ origin: true })` → reflects origin, duplicating the gateway injection
+- `cors()` with `callback(new Error(...))` for non-localhost → returns HTML 500 error page instead of JSON
 
 ### Health checks and autoscaling
 

--- a/skills/references/troubleshooting.md
+++ b/skills/references/troubleshooting.md
@@ -190,10 +190,12 @@ Causes (check in this order):
 - Mitigation: keep startup/initialization code minimal; move heavy setup to after `listen()`.
 
 ### AppSail cross-origin issues with Slate frontend
-- In development, Slate-hosted frontends calling AppSail APIs get blocked by Catalyst's auth
-  layer (manifests as "Unable to Fetch" or "Failed to fetch").
+- Slate-hosted frontends calling AppSail APIs may get blocked by Catalyst's auth layer
+  (manifests as "Unable to Fetch" or "Failed to fetch").
 - Fix: serve the frontend from AppSail itself using `express.static()` so all calls are
   same-origin. This eliminates CORS and auth-layer issues entirely.
+- **Note:** This issue is specific to AppSail. For Serverless Functions, cross-domain
+  from Slate DOES work — see the "Duplicate Access-Control-Allow-Origin" entry under Auth Errors.
 
 ---
 
@@ -226,6 +228,116 @@ Causes (check in this order):
 - ZAID (Zoho Application ID) differs between Development and Production environments.
 - This is the #1 source of auth issues when promoting to production.
 - Fix: always retrieve ZAID from the correct environment's console and update accordingly.
+
+### Duplicate `Access-Control-Allow-Origin` header (Slate + Serverless Functions)
+
+Error in browser console:
+```
+The 'Access-Control-Allow-Origin' header contains multiple values
+'https://myapp.onslate.com, https://myapp.onslate.com', but only one is allowed.
+```
+
+**Cause:** The Catalyst gateway injects `Access-Control-Allow-Origin` when the Slate domain is
+in Authorized Domains (Console → Authentication → Whitelisting). If your Express code ALSO sets
+this header (via `cors()` middleware or manual `res.setHeader`), the browser receives two values
+in one header and rejects the response.
+
+**Fix:** Remove ALL Express/function-level CORS headers for production origins. Only set CORS
+headers for `localhost` (local dev, where no gateway is present):
+```javascript
+app.use((req, res, next) => {
+  const origin = req.headers.origin || '';
+  if (/^http:\/\/localhost(:\d+)?$/.test(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    if (req.method === 'OPTIONS') return res.status(204).end();
+  }
+  next();
+});
+```
+
+**Key rule:** The gateway owns CORS headers for deployed origins. Express must not touch them.
+
+### `getCurrentUser()` returns `null` — collaborator vs app user
+
+`userManagement().getCurrentUser()` calls the internal `/project-user/current` endpoint using the
+user token. This only returns data for **registered app users** — users who signed up through
+Catalyst's auth flow (signUp/signIn).
+
+**Collaborators and project admins** (people added via the Catalyst console) are NOT registered
+app users. `getCurrentUser()` returns `null` for them, causing `Cannot read properties of null`
+errors if your code doesn't check for it.
+
+**Fix — add a null check with admin-scope fallback:**
+```javascript
+const userApp = catalyst.initialize(req);            // user-scope
+const userData = await userApp.userManagement().getCurrentUser();
+
+if (!userData || !userData.user_id) {
+  // Collaborator/admin — not in the project-user table.
+  // Fall back to admin-scope user list, or use a default identity.
+  const adminApp = catalyst.initialize(req, { scope: 'admin' });
+  const allUsers = await adminApp.userManagement().getAllUsers();
+  // Match by email or use a system identity
+}
+```
+
+### User-scope vs admin-scope: when to use each
+
+The SDK supports two initialization scopes. Using the wrong one causes auth failures:
+
+| Scope | Init call | Use for | What it CAN'T do |
+|-------|-----------|---------|-------------------|
+| **User** (default) | `catalyst.initialize(req)` | `getCurrentUser()`, user-identity operations | DataStore writes (if App User perms not enabled) |
+| **Admin** | `catalyst.initialize(req, { scope: 'admin' })` | DataStore CRUD, Stratus, ZCQL, Cache, all data operations | `getCurrentUser()` — throws "no user credentials present" |
+
+**Pattern for apps that need both auth and data ops:**
+```javascript
+// User-scope for identity
+const userApp = catalyst.initialize(req);
+const currentUser = await userApp.userManagement().getCurrentUser();
+
+// Admin-scope for data operations
+const adminApp = catalyst.initialize(req, { scope: 'admin' });
+const dataStore = adminApp.datastore();
+const table = dataStore.table('MyTable');
+```
+
+### `Authorization` header is `undefined` inside the function
+
+The Catalyst gateway **strips** the `Authorization` header after validating the token. It then
+injects internal `x-zc-*` headers that the SDK reads directly. Do not try to read
+`req.headers['authorization']` — it will be `undefined`. The SDK handles this internally via
+`catalyst.initialize(req)`.
+
+---
+
+## Slate Deployment Errors
+
+### `slate-config.toml` wiped by build commands
+
+The `.catalyst/slate-config.toml` file lives inside the build output directory (e.g., `dist/`).
+Build commands that clean the output directory (Vite `--clean`, Expo `--clear`, `rm -rf dist/`)
+delete this file. Without it, `catalyst deploy slate` fails.
+
+**Fix — recreate after every clean build:**
+```bash
+# Example for a React/Vite app
+npm run build && mkdir -p dist/.catalyst && \
+  echo -e 'framework = "static"\ndeployment_name = "default"' > dist/.catalyst/slate-config.toml && \
+  catalyst deploy slate
+```
+
+### Assets returning 404 on Slate (framework `baseUrl` issue)
+
+If your build tool has a `baseUrl` or `basePath` configured for a non-root path (e.g.,
+`/server/my_function`), all JS/CSS asset URLs will be prefixed with that path on Slate — but
+Slate serves from root `/`. This causes all assets to 404.
+
+**Fix:** Remove `baseUrl`/`basePath` from your build config before building for Slate deployment.
+Only set it when serving the frontend from inside a function or AppSail sub-path.
 
 ---
 


### PR DESCRIPTION
…dance

- Fix Slate → Serverless Function cross-domain (works with Authorized Domains + no Express CORS)
- Fix generateAuthToken() token path: access_token not content.token
- Remove Zoho-catalyst-appsail prefix from Authorization header
- Add user-scope vs admin-scope initialization guidance
- Add duplicate CORS header, getCurrentUser() null, slate-config.toml troubleshooting
- Add production promotion steps, targeted deploy recommendation
- Add gateway flow diagram showing x-zc-* header injection