### PR TITLE
Add agent survival guardrails (Danger Zone, CLI, AppSail)

### DIFF
--- a/catalyst-by-zoho/SKILL.md
+++ b/catalyst-by-zoho/SKILL.md
@@ -77,6 +77,21 @@ Look for `CatalystbyZoho_*` tools in your tool list.
 
 ---
 
+## Agent Danger Zone
+
+Before taking action in a Catalyst project, follow these hard rules:
+
+1. **Verify target identity before deploy or cleanup.** Print and verify org ID, project ID, project name, data center, component name, and target environment. Never infer these from memory or copied config. Run `catalyst whoami` and read `.catalystrc` before any destructive or deploy command.
+2. **Do not run interactive setup commands.** `catalyst init`, `catalyst login`, and menu-driven component-add flows can stall in agent/CI terminals. If required local config is missing, stop and ask the user to initialize it in their own terminal.
+3. **Timeout silent CLI commands.** If a Catalyst CLI command produces no output for about 60 seconds, stop retrying the same command. Record CLI version, Node/runtime context, and switch to a documented fallback or ask the user to complete the step manually.
+4. **Treat deployment success as untrusted.** Verify the deployed endpoint, logs, and one real behavior or artifact before declaring success. A green CLI exit code is not enough.
+5. **Treat cleanup as destructive.** Deleting, disabling, or overwriting Catalyst resources requires explicit user approval and a final target-ID check.
+6. **Capture product/docs/tool disagreements.** If docs, CLI behavior, SDK behavior, and MCP behavior disagree, document the discrepancy and ask for confirmation instead of guessing.
+
+For deploy/debug loops, also load `catalyst-by-zoho/references/agent-decision-tree.md`.
+
+---
+
 ## Catalyst at a Glance
 
 New to Catalyst? Here's what each service does in one line:

--- a/skills/catalyst-appsail/references/appsail-basics.md
+++ b/skills/catalyst-appsail/references/appsail-basics.md
@@ -321,6 +321,43 @@ Configure via Console → Domain Mapping.
 
 ---
 
+## OAuth and Domain Architecture
+
+Catalyst services run on different host patterns. **Session cookies do not cross domains.**
+
+| Host pattern | Typical use |
+|--------------|-------------|
+| `*.catalystserverless.in` | Functions, OAuth callbacks on function domain |
+| `*.catalystappsail.in` | AppSail apps |
+| `*.onslate.in` | Slate-hosted frontends |
+
+**Rule:** An OAuth/login function on `catalystserverless.in` that sets a session cookie will **not** authenticate requests to an AppSail app on `catalystappsail.in`. Options:
+
+- Host OAuth inside the AppSail app (same origin)
+- Use Catalyst domain mapping so auth and app share one domain
+- Use server-side token exchange instead of cross-domain cookies
+
+---
+
+## Filesystem Durability
+
+AppSail container filesystem is **not durable production storage**. Local files written at runtime can disappear on restart, redeploy, or scale events. Use Stratus or Data Store for anything that must survive.
+
+---
+
+## Post-Deploy Verification
+
+Do not declare AppSail success after CLI success alone. Verify:
+
+- Hosted URL returns expected HTTP status
+- One real application route or API call succeeds
+- Logs do not show startup/port binding failure
+- Expected side effects (DB row, Stratus object, etc.) exist when applicable
+
+If the hosted URL briefly reports AppSail disabled immediately after deploy, wait briefly and recheck status before changing configuration.
+
+---
+
 ## Common Errors
 
 | Error | Cause | Fix |

--- a/skills/catalyst-basics/references/cli.md
+++ b/skills/catalyst-basics/references/cli.md
@@ -715,7 +715,11 @@ catalyst <command> --help
 ### Critical Rules
 
 - **`--production` flag warning**: Any command with `--production` targets the live production environment. Always double-check the project context before using this flag.
-- **Always confirm project before mutating**: Run `catalyst whoami` and verify the project context before running any destructive or deployment command.
+- **Always confirm project before mutating**: Run `catalyst whoami` and verify the project context before running any destructive or deployment command. Print org ID, project ID, project name, DC, component name, and target environment before deploy **or cleanup**.
+- **Timeout silent CLI**: If any `catalyst` command produces no output for ~60 seconds, stop retrying. Record `catalyst --version`, Node/runtime versions, and switch strategy.
+- **Non-interactive stdin**: In agent or CI terminals, pipe stdin closed when a command may wait for input: `catalyst deploy appsail ... </dev/null` or run from an interactive user terminal.
+- **Colima on macOS**: If Docker commands fail mysteriously, verify the active socket. For Colima: `export ZC_DOCKER_SOCK_PATH="$HOME/.colima/default/docker.sock"` (or your Colima socket path) before AppSail Docker deploy.
+- **CLI tokens ≠ REST OAuth**: Output from `catalyst token:generate` is for Catalyst CLI/automation — not a generic REST `Authorization: Bearer` token unless docs explicitly say otherwise.
 
 ---
 
@@ -737,6 +741,8 @@ catalyst <command> --help
 | Token expired | Stale auth token | Run `catalyst token:generate` or `catalyst login --force` |
 | IAC status stuck | Long-running import/export | Run `catalyst iac:status` to check progress |
 | DS import fails | Malformed CSV or schema mismatch | Verify CSV format matches table schema; run `catalyst ds:status` |
+| CLI hangs with 0% CPU, no stdout | Node/CLI pairing issue or open stdin in non-interactive terminal | Stop after ~60s; try supported Node LTS; close stdin with `</dev/null`; ask user to run manually if hang persists |
+| AppSail Docker build fails on Mac | Wrong Docker socket (Colima vs Docker Desktop) | Set `ZC_DOCKER_SOCK_PATH` to the active provider socket before deploy |
 
 ### Debugging
 


### PR DESCRIPTION
## Summary

Community agent-session evidence shows agents waste hours on silent CLI hangs, wrong-project deploys, and false "deploy succeeded" conclusions. This PR adds a unified **Agent Danger Zone** and targeted CLI/AppSail guardrails.

## Changes

- `catalyst-by-zoho/SKILL.md` — Agent Danger Zone (identity verification, CLI timeout, untrusted deploy success, destructive cleanup)
- `skills/catalyst-basics/references/cli.md` — Colima socket, stdin hang, CLI token vs REST OAuth
- `skills/catalyst-appsail/references/appsail-basics.md` — OAuth domain split, filesystem durability, post-deploy verification

## Eval linkage

- APPSAIL-E001, E002, E003, E005

## Retirement path

Several guardrails are temporary until CLI stdin/hang behavior and AppSail env source-of-truth are clarified (see issues #4, #6).