### PR TITLE
Add Job, deploy, OAuth, and DataStore agent guardrails

### DIFF
--- a/catalyst-by-zoho/SKILL.md
+++ b/catalyst-by-zoho/SKILL.md
@@ -77,6 +77,21 @@ Look for `CatalystbyZoho_*` tools in your tool list.
 
 ---
 
+## Agent Danger Zone
+
+Before taking action in a Catalyst project, follow these hard rules:
+
+1. **Verify target identity before deploy or cleanup.** Print and verify org ID, project ID, project name, data center, component name, and target environment. Never infer these from memory or copied config. Run `catalyst whoami` and read `.catalystrc` before any destructive or deploy command.
+2. **Do not run interactive setup commands.** `catalyst init`, `catalyst login`, and menu-driven component-add flows can stall in agent/CI terminals. If required local config is missing, stop and ask the user to initialize it in their own terminal.
+3. **Timeout silent CLI commands.** If a Catalyst CLI command produces no output for about 60 seconds, stop retrying the same command. Record CLI version, Node/runtime context, and switch to a documented fallback or ask the user to complete the step manually.
+4. **Treat deployment success as untrusted.** Verify the deployed endpoint, logs, and one real behavior or artifact before declaring success. A green CLI exit code is not enough.
+5. **Treat cleanup as destructive.** Deleting, disabling, or overwriting Catalyst resources requires explicit user approval and a final target-ID check.
+6. **Capture product/docs/tool disagreements.** If docs, CLI behavior, SDK behavior, and MCP behavior disagree, document the discrepancy and ask for confirmation instead of guessing.
+
+For deploy/debug loops, also load `catalyst-by-zoho/references/agent-decision-tree.md`.
+
+---
+
 ## Catalyst at a Glance
 
 New to Catalyst? Here's what each service does in one line:

--- a/skills/catalyst-appsail/references/appsail-basics.md
+++ b/skills/catalyst-appsail/references/appsail-basics.md
@@ -321,6 +321,43 @@ Configure via Console → Domain Mapping.
 
 ---
 
+## OAuth and Domain Architecture
+
+Catalyst services run on different host patterns. **Session cookies do not cross domains.**
+
+| Host pattern | Typical use |
+|--------------|-------------|
+| `*.catalystserverless.in` | Functions, OAuth callbacks on function domain |
+| `*.catalystappsail.in` | AppSail apps |
+| `*.onslate.in` | Slate-hosted frontends |
+
+**Rule:** An OAuth/login function on `catalystserverless.in` that sets a session cookie will **not** authenticate requests to an AppSail app on `catalystappsail.in`. Options:
+
+- Host OAuth inside the AppSail app (same origin)
+- Use Catalyst domain mapping so auth and app share one domain
+- Use server-side token exchange instead of cross-domain cookies
+
+---
+
+## Filesystem Durability
+
+AppSail container filesystem is **not durable production storage**. Local files written at runtime can disappear on restart, redeploy, or scale events. Use Stratus or Data Store for anything that must survive.
+
+---
+
+## Post-Deploy Verification
+
+Do not declare AppSail success after CLI success alone. Verify:
+
+- Hosted URL returns expected HTTP status
+- One real application route or API call succeeds
+- Logs do not show startup/port binding failure
+- Expected side effects (DB row, Stratus object, etc.) exist when applicable
+
+If the hosted URL briefly reports AppSail disabled immediately after deploy, wait briefly and recheck status before changing configuration.
+
+---
+
 ## Common Errors
 
 | Error | Cause | Fix |

--- a/skills/catalyst-authentication/references/auth-basics.md
+++ b/skills/catalyst-authentication/references/auth-basics.md
@@ -157,6 +157,17 @@ if (!currentUser || !currentUser.user_id) {
 }
 ```
 
+### OAuth exactness checklist
+
+Agents should verify before debugging "mystery auth failures":
+
+- Redirect/callback URL matches **exactly** across env vars, auth URL, and API Console (including trailing slash rules).
+- `SESSION_SECRET` (or equivalent) is identical across functions that share auth cookies.
+- Cookie settings are compatible with the OAuth redirect flow.
+- `APP_ORIGIN` is domain-only without a trailing slash when docs require it.
+- Data-center env vars (`CATALYST_DATA_CENTER`, accounts URL) are set **before** importing/requiring the SDK when the SDK reads them at import time.
+- Use request-bound `catalyst.initialize(req)` inside handlers; use explicit app initialization only outside function context.
+
 ### `Authorization` header is `undefined`
 
 The Catalyst gateway strips the `Authorization` header after validation and injects `x-zc-*` internal headers. Do not read `req.headers['authorization']` — it will be `undefined`. The SDK reads `x-zc-*` headers automatically via `catalyst.initialize(req)`.

--- a/skills/catalyst-basics/references/cli.md
+++ b/skills/catalyst-basics/references/cli.md
@@ -715,7 +715,11 @@ catalyst <command> --help
 ### Critical Rules
 
 - **`--production` flag warning**: Any command with `--production` targets the live production environment. Always double-check the project context before using this flag.
-- **Always confirm project before mutating**: Run `catalyst whoami` and verify the project context before running any destructive or deployment command.
+- **Always confirm project before mutating**: Run `catalyst whoami` and verify the project context before running any destructive or deployment command. Print org ID, project ID, project name, DC, component name, and target environment before deploy **or cleanup**.
+- **Timeout silent CLI**: If any `catalyst` command produces no output for ~60 seconds, stop retrying. Record `catalyst --version`, Node/runtime versions, and switch strategy.
+- **Non-interactive stdin**: In agent or CI terminals, pipe stdin closed when a command may wait for input: `catalyst deploy appsail ... </dev/null` or run from an interactive user terminal.
+- **Colima on macOS**: If Docker commands fail mysteriously, verify the active socket. For Colima: `export ZC_DOCKER_SOCK_PATH="$HOME/.colima/default/docker.sock"` (or your Colima socket path) before AppSail Docker deploy.
+- **CLI tokens ≠ REST OAuth**: Output from `catalyst token:generate` is for Catalyst CLI/automation — not a generic REST `Authorization: Bearer` token unless docs explicitly say otherwise.
 
 ---
 
@@ -737,6 +741,8 @@ catalyst <command> --help
 | Token expired | Stale auth token | Run `catalyst token:generate` or `catalyst login --force` |
 | IAC status stuck | Long-running import/export | Run `catalyst iac:status` to check progress |
 | DS import fails | Malformed CSV or schema mismatch | Verify CSV format matches table schema; run `catalyst ds:status` |
+| CLI hangs with 0% CPU, no stdout | Node/CLI pairing issue or open stdin in non-interactive terminal | Stop after ~60s; try supported Node LTS; close stdin with `</dev/null`; ask user to run manually if hang persists |
+| AppSail Docker build fails on Mac | Wrong Docker socket (Colima vs Docker Desktop) | Set `ZC_DOCKER_SOCK_PATH` to the active provider socket before deploy |
 
 ### Debugging
 

--- a/skills/catalyst-basics/references/cli.md
+++ b/skills/catalyst-basics/references/cli.md
@@ -655,6 +655,16 @@ catalyst deploy slate <name> --no-wait -ni       # Don't wait for completion
 | `-m` | Deployment message (for Slate) |
 | `--production` | Deploy to production environment (CAUTION) |
 
+### Deploy guardrails for agents
+
+- **Prefer repo deploy scripts** when present (`scripts/deploy.sh`, `Makefile` targets). Inspect them first — they may sync shared files, validate targets, or pin SDK versions before raw `catalyst deploy`.
+- **Verify deploy output lists every expected component** (Functions, Client, Slate, AppSail). Missing sections mean a partial deploy even when the CLI exits 0.
+- **Function packaging**: each function deploys as its own package. Copy shared modules into every function directory before deploy when the repo uses a sync step.
+- **Function registration**: adding a name to `catalyst.json` alone does not register a new function. The user must run `catalyst functions:add` interactively once, or follow the documented manual scaffold workaround in this file.
+- **Exact stack values**: use documented strings such as `python_3_9`, not guessed forms like `python39`.
+- **Destructive overwrite**: treat `functions:add --overwrite` and remote delete commands as destructive — require explicit user approval.
+- **Stale local execute**: when `catalyst functions:execute` runs old code, delete `functions/<name>/.build` and retry.
+
 ---
 
 ## Other Commands

--- a/skills/catalyst-datastore/references/datastore-basics.md
+++ b/skills/catalyst-datastore/references/datastore-basics.md
@@ -299,6 +299,16 @@ Data Store does NOT support multi-statement transactions.
 
 ---
 
+## Row Operation Exactness
+
+- **ROWID is a string** in SDK calls — preserve string shape; do not coerce large IDs to numbers.
+- **Use table row scopes** appropriate to the operation — do not assume a broad table scope covers row-level CRUD.
+- **Avoid reserved/system column names** in custom schemas (`ROWID`, `CREATORID`, `CREATEDTIME`, `MODIFIEDTIME` are system-managed).
+- **Bulk delete**: respect documented batch limits; pass comma-separated ROWID strings where required by the API.
+- **Smoke-test** single-row create → read → delete before bulk seed or reset scripts.
+
+---
+
 ## Concurrency Limits
 
 - Default: **10 concurrent executions** per function per environment

--- a/skills/catalyst-functions/references/functions-templates.md
+++ b/skills/catalyst-functions/references/functions-templates.md
@@ -127,6 +127,12 @@ def handler(job_request, context):
 - `context.close_with_success()` — mark job succeeded
 - `context.close_with_failure()` — mark job failed
 
+### Local test vs deployed runtime
+
+`catalyst functions:execute` does not prove deployed environment variables, scheduled timing, or Job pool behavior. Verify long-running Job logic with a remote scheduled run after local smoke tests.
+
+Clear stale build artifacts before local execute loops: `rm -rf functions/<name>/.build` when edited source does not appear in execute output.
+
 ---
 
 ## Integration Function Template

--- a/skills/catalyst-sdk/references/sdk-python.md
+++ b/skills/catalyst-sdk/references/sdk-python.md
@@ -270,3 +270,5 @@ output = smart_browz.generate_from_template(
 | Error | Cause | Fix |
 |-------|-------|-----|
 | DataStore methods hang silently in Job functions | `zcatalyst_sdk` Table methods (`get_paged_rows`, `delete_rows`, `insert_rows`, etc.) use `CredentialUser.USER` internally. Job functions have no USER token — every call makes an unauthenticated request, waits 60 s per attempt, raises no exception, and silently burns toward the 15-minute timeout | Initialize with `scope='admin'`: `zcatalyst_sdk.initialize(req=context, scope='admin')` |
+| `CatalystAppError: Catalyst headers are empty` in Python Job | Incorrect scope or missing admin initialization | Verify `scope='admin'` is passed to `zcatalyst_sdk.initialize()` in Job functions |
+| Pinning mismatch after CLI scaffold | CLI may suggest a newer `zcatalyst-sdk` than the function stack supports | Pin `zcatalyst-sdk` to a version compatible with the selected Python stack (e.g. `python_3_9`) |

--- a/skills/catalyst-slate/references/slate-basics.md
+++ b/skills/catalyst-slate/references/slate-basics.md
@@ -72,6 +72,8 @@ deployment_name = "default"
 "slate": [{ "name": "my-frontend", "source": "/absolute/path/to/client" }]
 ```
 
+> ⚠️ **Verify Slate source paths before deploy.** Root path, install command, build command, and `catalyst.json` `source` must point at the directory that contains the built artifact (often `dist/`). Use repo-relative paths in documentation examples but absolute paths in local `catalyst.json` when required by the CLI. After deploy, confirm the hosted Slate URL serves fresh assets (not a stale prior build).
+
 **Step 3** — Deploy:
 ```bash
 catalyst deploy slate -m "initial deploy"


### PR DESCRIPTION
## Summary

Adds operational troubleshooting for Function/Job/DataStore workflows that fail silently or appear to succeed while running stale code.

## Changes

- `skills/catalyst-functions/references/functions-templates.md` — Python `dir(context)` before initialize, Job runtime limits, ZCQL UPDATE vs PUT hang, local execute vs deployed runtime
- `skills/catalyst-sdk/references/sdk-python.md` — Job init and update-row hang fixes
- `skills/catalyst-basics/references/cli.md` — deploy wrappers, packaging, registration, stale `.build`
- `skills/catalyst-slate/references/slate-basics.md` — source path verification
- `skills/catalyst-datastore/references/datastore-basics.md` — row operation exactness
- `skills/catalyst-authentication/references/auth-basics.md` — OAuth exactness checklist

Builds on agent survival PR (Danger Zone / CLI / AppSail sections).

## Retirement path

PUT-in-Job workaround and Python header injection guardrail should be retired after product confirmation (issue #5 follow-up).