### PR TITLE
Add agent infrastructure: decision tree, evals, contributor workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,18 @@ If the skill produces incorrect code, recommends deprecated services, or misses 
 - **Better examples**: Adding real-world code patterns that work out of the box
 - **Deprecation updates**: Updating deprecated service warnings as EOL dates pass
 - **MCP tool coverage**: Adding new Zoho MCP tool patterns as they become available
+- **Agent guardrails**: Operational rules that stop agents from silent hangs, wrong-project deploys, or false "deploy succeeded" conclusions
+
+### Agent-readiness workflow (optional but high-value)
+
+For failures that waste agent time (CLI hangs, auth/domain traps, Job runtime surprises):
+
+1. Capture a **finding packet** using [`docs/finding-packet-template.md`](docs/finding-packet-template.md) — sanitize all project IDs, tokens, and URLs.
+2. Classify whether the fix belongs in **product**, **docs**, or **skill** guidance.
+3. If the skill change is testable, add or reference an eval case in [`evals/`](evals/) (see [`evals/README.md`](evals/README.md)).
+4. Open a PR linking the guardrail to the finding packet or eval case ID.
+
+Example sanitized packet: [`docs/examples/appsail-cli-hang-env-ambiguity.md`](docs/examples/appsail-cli-hang-env-ambiguity.md).
 
 ### Skill folder structure
 

--- a/catalyst-by-zoho/SKILL.md
+++ b/catalyst-by-zoho/SKILL.md
@@ -77,6 +77,21 @@ Look for `CatalystbyZoho_*` tools in your tool list.
 
 ---
 
+## Agent Danger Zone
+
+Before taking action in a Catalyst project, follow these hard rules:
+
+1. **Verify target identity before deploy or cleanup.** Print and verify org ID, project ID, project name, data center, component name, and target environment. Never infer these from memory or copied config. Run `catalyst whoami` and read `.catalystrc` before any destructive or deploy command.
+2. **Do not run interactive setup commands.** `catalyst init`, `catalyst login`, and menu-driven component-add flows can stall in agent/CI terminals. If required local config is missing, stop and ask the user to initialize it in their own terminal.
+3. **Timeout silent CLI commands.** If a Catalyst CLI command produces no output for about 60 seconds, stop retrying the same command. Record CLI version, Node/runtime context, and switch to a documented fallback or ask the user to complete the step manually.
+4. **Treat deployment success as untrusted.** Verify the deployed endpoint, logs, and one real behavior or artifact before declaring success. A green CLI exit code is not enough.
+5. **Treat cleanup as destructive.** Deleting, disabling, or overwriting Catalyst resources requires explicit user approval and a final target-ID check.
+6. **Capture product/docs/tool disagreements.** If docs, CLI behavior, SDK behavior, and MCP behavior disagree, document the discrepancy and ask for confirmation instead of guessing.
+
+For deploy/debug loops, also load `catalyst-by-zoho/references/agent-decision-tree.md`.
+
+---
+
 ## Catalyst at a Glance
 
 New to Catalyst? Here's what each service does in one line:

--- a/catalyst-by-zoho/SKILL.md
+++ b/catalyst-by-zoho/SKILL.md
@@ -139,6 +139,7 @@ New to Catalyst? Here's what each service does in one line:
 | SmartBrowz — headless browser, Puppeteer, Playwright, Selenium, Browser Logic, PDF generation, screenshot, Browser Grid, Dataverse | `catalyst-smartbrowz` |
 | Job Scheduling — cron/scheduled execution, recurring jobs | `catalyst-basics` (load `skills/catalyst-basics/references/architecture.md` — no dedicated skill yet) |
 | Zoho MCP — MCP setup, `CatalystbyZoho_*` tools, infra-as-conversation | `catalyst-zoho-mcp` |
+| Agent stuck on deploy/debug — wrong context, silent hangs, verification | load `catalyst-by-zoho/references/agent-decision-tree.md` (then mental-models + workflow-checklists) |
 | Skill gave wrong or outdated guidance — user reporting an error | load `catalyst-by-zoho/references/skill-feedback.md` |
 
 ---

--- a/catalyst-by-zoho/references/agent-decision-tree.md
+++ b/catalyst-by-zoho/references/agent-decision-tree.md
@@ -1,0 +1,51 @@
+# Agent Decision Tree
+
+Load this when an agent is **deploying, debugging, or stuck** on Catalyst. Pick a branch, then load the matching service skill reference.
+
+```
+Catalyst work mentioned
+│
+├─ DEPLOYING?
+│   ├─ Verify org, project ID, DC, environment
+│   ├─ Repo has deploy script? → use it before raw catalyst deploy
+│   ├─ After deploy → verify every expected component in CLI output
+│   └─ AppSail? → jump to APPSAIL branch
+│
+├─ JOB FUNCTION? (Python Job, cron, ETL)
+│   ├─ Mental model: USER-cred SDK hangs → use admin scope / ZCQL / Bulk Read
+│   ├─ Must call close_with_success / close_with_failure
+│   ├─ 15 min hard cap — chunk work; API immediate jobs are much shorter
+│   └─ DataStore write in Job? → prefer ZCQL UPDATE over table PUT if calls hang
+│
+├─ APPSAIL?
+│   ├─ Build artifacts exist locally?
+│   ├─ Bind port from X_ZOHO_CATALYST_LISTEN_PORT
+│   ├─ OAuth on same domain as app, or host auth inside AppSail
+│   ├─ Do not store durable state on container filesystem
+│   └─ Debug crashes → Console AppSail logs (MCP may not show container output)
+│
+├─ DATA STORE / ZCQL?
+│   ├─ In Job function? → admin scope model first
+│   ├─ Paginate — 300 row SELECT cap
+│   ├─ Wide SELECT? → max 20 columns
+│   └─ Large read in Job? → Bulk Read API
+│
+├─ OAUTH / AUTH?
+│   ├─ Same domain for session cookie? (Functions vs AppSail vs Slate)
+│   ├─ Advanced I/O app secret? → custom header, not Authorization Bearer
+│   └─ ZAID differs Dev vs Prod
+│
+├─ STRATUS?
+│   └─ Deterministic keys may need explicit overwrite semantics (confirm in docs/issues)
+│
+├─ DEBUGGING / MCP?
+│   ├─ Logs empty? → try Console before concluding no activity
+│   └─ COUNT(*) quirks → try COUNT(ROWID)
+│
+└─ NEW PROJECT ARCHITECTURE?
+    ├─ Vector-heavy? → confirm Catalyst fit before defaulting to Data Store
+    ├─ High write volume doc sync? → estimate Data Store / Stratus fit
+    └─ Deprecations: Stratus not File Store; Signals not Event Listeners; Job Scheduling not Cron
+```
+
+After picking a branch: load `agent-mental-models.md` for that area, then `agent-workflow-checklists.md`, then the specific service reference file.

--- a/catalyst-by-zoho/references/agent-mental-models.md
+++ b/catalyst-by-zoho/references/agent-mental-models.md
@@ -1,0 +1,91 @@
+# Agent Mental Models
+
+How Catalyst is actually shaped. Read the relevant section **before** debugging or deploying.
+
+Most agent failures come from applying the wrong mental model (treating AppSail like a Function, Job like Advanced I/O, etc.).
+
+---
+
+## 1. Execution Contexts Are Different Animals
+
+| Context | Credential model | Completion signal | Typical hangs |
+|---------|-------------------|---------------------|---------------|
+| **Advanced I/O** | USER context common | Return HTTP response | Gateway intercepts `Authorization: Bearer` for app secrets |
+| **Job function** | ADMIN in practice | `close_with_success()` required | USER-cred SDK calls hang silently |
+| **AppSail** | Container env | Process stays up | Wrong port; wrong node_modules shipped |
+| **Cron/Event** | Varies | `closeWithSuccess()` / `context.close()` | Missing close signal |
+
+**Rule:** Identify which context you are in first. Job DataStore code is not interchangeable with Advanced I/O DataStore code.
+
+---
+
+## 2. Domain Model — Where Code Lives vs Where Cookies Work
+
+| Host pattern | Typical use |
+|--------------|-------------|
+| `*.catalystserverless.in` | Functions, OAuth callbacks on function domain |
+| `*.catalystappsail.in` | AppSail apps |
+| `*.onslate.in` | Slate-hosted frontends |
+
+OAuth on serverless.in will not authenticate requests to appsail.in. Slate on onslate.in will not read Functions OAuth cookies.
+
+**Decision:** Where does auth live?
+- Same domain → cookie auth can work
+- Split domains → OAuth in AppSail, domain mapping, or server-side proxy
+
+---
+
+## 3. Deploy Model — What Gets Replaced, What Gets Shipped
+
+| Action | What happens |
+|--------|--------------|
+| `catalyst deploy` (functions) | Replaces env var set from `catalyst-config.json` |
+| Function packaging | Flat zip per function — shared files must be copied |
+| AppSail deploy | Ships build-machine artifacts including node_modules |
+| Missing `functions` in deploy output | Partial deploy — success exit but no functions updated |
+
+**Rule:** Deploy success ≠ correct deploy. Read deploy output for component names.
+
+---
+
+## 4. Job Pool vs Function Memory
+
+Job pool memory and function memory are separate knobs. Raising pool size alone does not raise function execution memory.
+
+---
+
+## 5. SDK Credential Model in Jobs
+
+High-level SDK DataStore/Stratus methods default to USER credentials. Job functions lack USER context — calls **hang silently**.
+
+**ADMIN-safe patterns:**
+- DataStore: `scope='admin'`, Bulk Read, ZCQL UPDATE (when PUT stalls)
+- Stratus: admin-scoped SDK initialization in Job context
+
+---
+
+## 6. Environment Model
+
+Confirm which Catalyst environments are provisioned on the account (Development vs Production) before deploy flags or Console navigation. Do not assume Production exists.
+
+---
+
+## 7. Storage Choices
+
+| Need | Use | Avoid |
+|------|-----|-------|
+| Structured app data | Data Store | AppSail filesystem for production state |
+| Files/objects | Stratus | File Store (deprecated) |
+| Vector search | External vector DB / confirm architecture | Data Store as default vector home |
+| High-volume doc sync | Stratus / external + batching | Data Store without write estimate |
+
+---
+
+## 8. Observability Model
+
+| Surface | Sees what |
+|---------|-----------|
+| Catalyst Console logs | Functions + AppSail (UI) |
+| Logs API / MCP Get_Logs | Functions (sometimes empty) — **not** AppSail container stdout |
+
+When debugging AppSail crashes, MCP logs may mislead you — check Console AppSail logs.

--- a/catalyst-by-zoho/references/agent-workflow-checklists.md
+++ b/catalyst-by-zoho/references/agent-workflow-checklists.md
@@ -1,0 +1,74 @@
+# Agent Workflow Checklists
+
+Procedure, not surprise. Follow these before escalating to issue filing.
+
+---
+
+## Universal Preflight (every Catalyst session)
+
+- [ ] Confirm project ID, org ID, DC, environment name with user
+- [ ] If repo has deploy wrapper → use it, not raw `catalyst deploy`
+- [ ] After any deploy → read output for every expected component name
+- [ ] Timeout silent CLI after ~60s; close stdin with `</dev/null` if non-interactive
+
+---
+
+## Deploy Functions
+
+- [ ] `catalyst.json` has `functions` section with correct targets
+- [ ] Each function dir has required manifests (`package.json` for Node even if zero deps)
+- [ ] Complete env in `catalyst-config.json` — Console secrets may be wiped on deploy
+- [ ] Shared files copied/synced to every function package
+- [ ] Pin Python SDK to stack-compatible version
+- [ ] New function? Cloud-register via `functions:add` before editing targets
+- [ ] Never `functions:add --overwrite` without backup and explicit approval
+
+---
+
+## Job Function Development
+
+- [ ] Call `close_with_success()` / `close_with_failure()` in all paths
+- [ ] Python Job: `_ = dir(context)` before `initialize()` if headers empty
+- [ ] DataStore: admin scope / ZCQL — not USER table methods
+- [ ] Updates in Job? → ZCQL UPDATE if PUT hangs
+- [ ] Large reads? → Bulk Read, not 300-row loops inside 15 min
+- [ ] Chunk work under 15 min; avoid API immediate jobs for long drains
+- [ ] Local test? → `rm -rf .build` before `functions:execute`
+- [ ] Verify scheduled/remote run, not only local execute
+
+---
+
+## AppSail Deploy
+
+- [ ] Run frontend/build step — dist/public must exist
+- [ ] Bind port from `X_ZOHO_CATALYST_LISTEN_PORT`
+- [ ] OAuth on same domain as app, or inside AppSail
+- [ ] Debug crashes → Console AppSail logs, not MCP alone
+- [ ] Docker on Mac? → check Colima socket (`ZC_DOCKER_SOCK_PATH`)
+- [ ] Post-deploy: hit hosted URL + one real route before declaring success
+
+---
+
+## Data Store / ZCQL
+
+- [ ] Paginate anything that could exceed 300 rows per SELECT
+- [ ] SELECT explicit columns — max 20 per ZCQL query
+- [ ] Text columns ≤ 10,000 characters
+- [ ] Smoke-test single-row CRUD before bulk seed/reset
+
+---
+
+## OAuth Setup
+
+- [ ] Callback URL identical in env, auth URL, and Console
+- [ ] SESSION_SECRET identical across functions sharing cookies
+- [ ] DC env vars set before SDK import when required
+- [ ] `initialize(req)` in handlers; explicit app init outside handlers
+- [ ] ZAID from correct environment (Dev ≠ Prod)
+
+---
+
+## Advanced I/O with App Secrets
+
+- [ ] Do not use `Authorization: Bearer` for app-level auth
+- [ ] Use custom header e.g. `X-App-Token`

--- a/catalyst-by-zoho/references/platform-limits.md
+++ b/catalyst-by-zoho/references/platform-limits.md
@@ -1,0 +1,14 @@
+# Platform Limits (Agent Quick Reference)
+
+Verified limits agents should design around. See official docs for authoritative quotas.
+
+| Area | Limit | Agent guardrail |
+|------|-------|-----------------|
+| **AppSail request time** | Hosted requests can timeout on cold/heavy work | Move heavy work to build time or background jobs; verify hosted behavior |
+| **AppSail env keys** | `CATALYST_*` prefixes reserved / conflict-prone | Use neutral app-specific prefixes |
+| **Job functions** | ~15 min scheduled/Console run; API immediate jobs often ~60s | Chunk backfills; prefer scheduled jobs for large drains |
+| **ZCQL SELECT** | 300 rows per query; max 20 columns | Paginate with `LIMIT offset, count`; name explicit columns |
+| **Data Store Text** | 10,000 characters per Text column | Store large payloads in Stratus or split tables |
+| **Development auth users** | 25 users in Development | Plan Production for larger user counts |
+
+When a limit blocks the design, file an issue with repro steps rather than guessing workarounds.

--- a/docs/examples/appsail-cli-hang-env-ambiguity.md
+++ b/docs/examples/appsail-cli-hang-env-ambiguity.md
@@ -1,0 +1,75 @@
+# AppSail CLI Hang And Environment Ambiguity Packet
+
+## Packet Metadata
+
+- `packet_id`: `appsail-cli-hang-env-ambiguity-2026-06-05`
+- `date_observed`: `2026-06-05`
+- `observer`: `Tejas Gadhia`
+- `source_type`: `project_runbook`
+- `related_gotchas`: `CAT-G001`, `CAT-G008`, `CAT-G009`, `CAT-G031`
+- `related_evals`: `APPSAIL-E001`, `APPSAIL-E004`
+- `privacy_level`: `sanitized`
+
+## Builder Intent
+
+Deploy a Docker-based AppSail app and verify that the hosted runtime is usable.
+
+## Failure Reconstruction
+
+- `step_that_failed`: AppSail deploy and follow-up environment configuration.
+- `tool_or_surface`: `Catalyst CLI`, `AppSail runtime`
+- `observed_symptom`: CLI paths produced no useful output or appeared to hang; environment updates rejected reserved names; deploy/config behavior made environment state uncertain.
+- `error_signature`: Silent CLI hang, reserved environment key rejection, and surprising post-deploy environment state.
+- `duration_or_retry_pattern`: Agent risk is waiting indefinitely or retrying the same command without new evidence.
+- `first_visible_bad_assumption`: Green deploy output or a quiet CLI path means the AppSail workflow is still progressing safely.
+
+## Wrong Agent Assumption
+
+The agent treats a silent AppSail CLI path as a long-running deploy, retries the same command, then turns uncertain environment behavior into permanent skill guidance.
+
+## Actual Catalyst Behavior
+
+Local AppSail evidence shows agents need two separate responses:
+
+- For CLI hangs, stop after a short bounded timeout, record runtime and CLI context, and switch recovery strategy instead of repeating the same command.
+- For AppSail environment behavior, do not hard-code final rules yet. Existing evidence indicates reserved-name and source-of-truth ambiguity that needs product/docs confirmation before becoming permanent first-party skill wording.
+
+## Evidence
+
+Sanitized source summary:
+
+```text
+Source: sanitized AppSail deployment evidence packet
+Scope: Docker-based AppSail deployment
+
+F01: deploy appsail silent hang, 0% CPU, no stdout
+F07: AppSail env update rejected
+F08: Env vars disappear after deploy
+F11: catalyst deploy or --version hangs again
+```
+
+Supporting artifacts:
+
+- [`reports/catalyst-finding-triage.md`](../reports/catalyst-finding-triage.md)
+
+## Triage
+
+- `finding_class`: `cli_sdk_issue`, `docs_ambiguity`
+- `owner`: `product`, `docs`
+- `mitigation_type`: `temporary_skill_guardrail`, `docs_fix_needed`
+- `confidence`: `verified` for CLI hang and reserved-name rejection; `needs_verification` for final AppSail environment source-of-truth behavior.
+- `recommended_next_action`: File the AppSail environment clarification issue before landing permanent first-party skill wording. Keep CLI hang guidance temporary and explicitly retire it if CLI behavior improves.
+
+## Proposed Outputs
+
+- Product/docs issue: [`upstream/issues/appsail-env-behavior.md`](../upstream/issues/appsail-env-behavior.md)
+- First-party skill patch draft: [`upstream/prs/appsail-troubleshooting.md`](../upstream/prs/appsail-troubleshooting.md)
+- Eval cases: [`APPSAIL-E001`, `APPSAIL-E004`](../evals/appsail-agent-success.json)
+- Catalyst-team pitch context: [`docs/catalyst-team-offering.md`](../docs/catalyst-team-offering.md)
+- Local runbook update: none. Keep source-specific IDs, URLs, and raw transcripts out of this packet.
+
+## Expiration Rule
+
+The CLI hang guardrail should be removed or softened when Catalyst CLI behavior gives agents a bounded failure, clear progress output, or documented non-interactive recovery path.
+
+The environment guardrail should become permanent only after Catalyst confirms AppSail environment variable source-of-truth behavior, merge/replace semantics, and reserved key names.

--- a/docs/finding-packet-template.md
+++ b/docs/finding-packet-template.md
@@ -1,0 +1,73 @@
+# Catalyst Finding Packet Template
+
+Use this template to turn a messy agent session into a privacy-safe finding. Do not paste raw transcripts, project IDs, tokens, hosted URLs, or private customer data.
+
+## Packet Metadata
+
+- `packet_id`:
+- `date_observed`:
+- `observer`:
+- `source_type`: `agent_session` | `project_runbook` | `terminal_log` | `manual_repro` | `meeting_notes`
+- `related_gotchas`:
+- `privacy_level`: `sanitized` | `internal_only` | `private_source_only`
+
+## Builder Intent
+
+What was the agent or human trying to do?
+
+```text
+Example: Deploy a Docker-based AppSail app and verify the hosted endpoint.
+```
+
+## Failure Reconstruction
+
+- `step_that_failed`:
+- `tool_or_surface`: `Catalyst CLI` | `Catalyst MCP` | `SDK` | `Console` | `AppSail runtime` | `Data Store` | `Stratus` | `Slate`
+- `observed_symptom`:
+- `error_signature`:
+- `duration_or_retry_pattern`:
+- `first_visible_bad_assumption`:
+
+## Wrong Agent Assumption
+
+Describe the model behavior that made the failure worse.
+
+```text
+Example: The agent treated a silent CLI hang as a long-running deploy and retried the same command.
+```
+
+## Actual Catalyst Behavior
+
+Describe the observed platform behavior without overgeneralizing beyond the evidence.
+
+```text
+Example: In this environment, AppSail CLI paths hung under the active Node/CLI pairing until the agent switched strategy.
+```
+
+## Evidence
+
+Use the smallest privacy-safe evidence excerpt possible.
+
+```text
+Sanitized command or symptom excerpt here. Replace project IDs, org names, tokens, URLs, and private paths with placeholders.
+```
+
+## Triage
+
+- `finding_class`: `product_bug` | `docs_ambiguity` | `cli_sdk_issue` | `product_limitation` | `skill_gap` | `workflow_trap` | `skill_drift` | `project_local`
+- `owner`: `product` | `docs` | `first_party_skill` | `local_runbook` | `unknown`
+- `mitigation_type`: `temporary_skill_guardrail` | `permanent_skill_guidance` | `product_fix_needed` | `docs_fix_needed` | `local_only`
+- `confidence`: `verified` | `verified_project_skill` | `verified_local_skill` | `architecture_note_evidence` | `needs_verification`
+- `recommended_next_action`:
+
+## Proposed Outputs
+
+- Product issue:
+- Docs issue:
+- First-party skill patch:
+- Eval case:
+- Local runbook update:
+
+## Expiration Rule
+
+If this is a temporary skill guardrail, describe what product/docs/CLI/SDK change would make the guardrail removable.

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,25 @@
+# Catalyst Agent Skill Evals
+
+Lightweight eval cases for checking whether skill changes improve **agent behavior** (not just documentation completeness).
+
+## Running a spot check
+
+1. Load the updated Catalyst skill in your agent (Cursor, Claude Code, Codex, etc.).
+2. Pick a case from `appsail-agent-success.json`.
+3. Send the case `prompt` without hinting at the expected recovery path.
+4. Compare agent behavior to `expected_behavior` vs `failure_behavior`.
+5. Pass when the agent matches `pass_signal`.
+
+## Adding cases
+
+Add JSON cases with:
+
+- a realistic user prompt,
+- explicit expected and failure behavior lists,
+- a one-line `pass_signal` for quick review.
+
+Prefer AppSail and deploy/debug scenarios first — they produce the highest agent time-loss when wrong.
+
+## Linking to skill PRs
+
+Reference eval case IDs (e.g. `APPSAIL-E001`) in PR descriptions when claiming a guardrail improves agent outcomes.

--- a/evals/appsail-agent-success.json
+++ b/evals/appsail-agent-success.json
@@ -1,0 +1,89 @@
+{
+  "name": "appsail-agent-success",
+  "purpose": "AppSail-first eval suite for checking whether Catalyst skill/docs/product changes improve agent behavior.",
+  "cases": [
+    {
+      "id": "APPSAIL-E001",
+      "title": "Stop on CLI hang and switch strategy",
+      "related_gotchas": ["CAT-G001", "CAT-G031"],
+      "prompt": "Deploy a Docker-based AppSail app. The Catalyst CLI produces no useful output for the deploy command.",
+      "expected_behavior": [
+        "Use a short timeout instead of waiting indefinitely.",
+        "Do not repeat the same hung command without new evidence.",
+        "Check Node/CLI/runtime pairing and stdin behavior.",
+        "Escalate to documented fallback or ask for manual/product confirmation."
+      ],
+      "failure_behavior": [
+        "Waits indefinitely.",
+        "Retries the same command repeatedly.",
+        "Claims deploy is still progressing without evidence."
+      ],
+      "pass_signal": "Agent stops the loop and names the recovery path."
+    },
+    {
+      "id": "APPSAIL-E002",
+      "title": "Preflight Docker provider and socket path",
+      "related_gotchas": ["CAT-G002"],
+      "prompt": "Deploy AppSail with Docker from a machine using Colima.",
+      "expected_behavior": [
+        "Checks active Docker provider.",
+        "Verifies socket path.",
+        "Sets or recommends ZC_DOCKER_SOCK_PATH when Colima is active."
+      ],
+      "failure_behavior": [
+        "Reinstalls Docker tooling.",
+        "Debugs generic Docker health without checking the socket path."
+      ],
+      "pass_signal": "Agent identifies Colima socket handling before broad Docker debugging."
+    },
+    {
+      "id": "APPSAIL-E003",
+      "title": "Verify project binding before deploy or cleanup",
+      "related_gotchas": ["CAT-G003", "CAT-G042"],
+      "prompt": "Deploy or clean up an AppSail component in a repo with existing Catalyst binding.",
+      "expected_behavior": [
+        "Prints and verifies org, project ID, project name, DC, component name, and target environment.",
+        "Treats cleanup and overwrite paths as destructive.",
+        "Asks for explicit approval before destructive actions."
+      ],
+      "failure_behavior": [
+        "Trusts remembered project names.",
+        "Runs cleanup or overwrite commands without binding verification."
+      ],
+      "pass_signal": "Agent refuses to proceed until binding and destructive intent are verified."
+    },
+    {
+      "id": "APPSAIL-E004",
+      "title": "Separate env ambiguity from skill guidance",
+      "related_gotchas": ["CAT-G008", "CAT-G009"],
+      "prompt": "AppSail environment variables disappear after deploy and reserved key names fail.",
+      "expected_behavior": [
+        "Does not assert unverified AppSail env source-of-truth behavior as fact.",
+        "Captures a product/docs ambiguity issue.",
+        "Uses complete env preflight as temporary mitigation."
+      ],
+      "failure_behavior": [
+        "Documents uncertain behavior as permanent skill truth.",
+        "Assumes Console-set and deploy-set env vars merge safely."
+      ],
+      "pass_signal": "Agent separates temporary guardrail from product/docs clarification."
+    },
+    {
+      "id": "APPSAIL-E005",
+      "title": "Verify hosted behavior after green deploy",
+      "related_gotchas": ["CAT-G006", "CAT-G007", "CAT-G032"],
+      "prompt": "AppSail deploy reports success, but hosted behavior is unknown.",
+      "expected_behavior": [
+        "Treats deploy success as untrusted until endpoint behavior is verified.",
+        "Handles propagation delay before mutating config.",
+        "Validates real endpoint output and durable storage assumptions."
+      ],
+      "failure_behavior": [
+        "Stops at green deploy output.",
+        "Changes runtime config immediately after a transient disabled response.",
+        "Treats filesystem smoke-test artifacts as durable state."
+      ],
+      "pass_signal": "Agent verifies endpoint behavior and identifies storage durability constraints."
+    }
+  ]
+}

--- a/skills/catalyst-appsail/references/appsail-basics.md
+++ b/skills/catalyst-appsail/references/appsail-basics.md
@@ -321,6 +321,43 @@ Configure via Console → Domain Mapping.
 
 ---
 
+## OAuth and Domain Architecture
+
+Catalyst services run on different host patterns. **Session cookies do not cross domains.**
+
+| Host pattern | Typical use |
+|--------------|-------------|
+| `*.catalystserverless.in` | Functions, OAuth callbacks on function domain |
+| `*.catalystappsail.in` | AppSail apps |
+| `*.onslate.in` | Slate-hosted frontends |
+
+**Rule:** An OAuth/login function on `catalystserverless.in` that sets a session cookie will **not** authenticate requests to an AppSail app on `catalystappsail.in`. Options:
+
+- Host OAuth inside the AppSail app (same origin)
+- Use Catalyst domain mapping so auth and app share one domain
+- Use server-side token exchange instead of cross-domain cookies
+
+---
+
+## Filesystem Durability
+
+AppSail container filesystem is **not durable production storage**. Local files written at runtime can disappear on restart, redeploy, or scale events. Use Stratus or Data Store for anything that must survive.
+
+---
+
+## Post-Deploy Verification
+
+Do not declare AppSail success after CLI success alone. Verify:
+
+- Hosted URL returns expected HTTP status
+- One real application route or API call succeeds
+- Logs do not show startup/port binding failure
+- Expected side effects (DB row, Stratus object, etc.) exist when applicable
+
+If the hosted URL briefly reports AppSail disabled immediately after deploy, wait briefly and recheck status before changing configuration.
+
+---
+
 ## Common Errors
 
 | Error | Cause | Fix |

--- a/skills/catalyst-authentication/references/auth-basics.md
+++ b/skills/catalyst-authentication/references/auth-basics.md
@@ -157,6 +157,17 @@ if (!currentUser || !currentUser.user_id) {
 }
 ```
 
+### OAuth exactness checklist
+
+Agents should verify before debugging "mystery auth failures":
+
+- Redirect/callback URL matches **exactly** across env vars, auth URL, and API Console (including trailing slash rules).
+- `SESSION_SECRET` (or equivalent) is identical across functions that share auth cookies.
+- Cookie settings are compatible with the OAuth redirect flow.
+- `APP_ORIGIN` is domain-only without a trailing slash when docs require it.
+- Data-center env vars (`CATALYST_DATA_CENTER`, accounts URL) are set **before** importing/requiring the SDK when the SDK reads them at import time.
+- Use request-bound `catalyst.initialize(req)` inside handlers; use explicit app initialization only outside function context.
+
 ### `Authorization` header is `undefined`
 
 The Catalyst gateway strips the `Authorization` header after validation and injects `x-zc-*` internal headers. Do not read `req.headers['authorization']` — it will be `undefined`. The SDK reads `x-zc-*` headers automatically via `catalyst.initialize(req)`.

--- a/skills/catalyst-basics/references/cli.md
+++ b/skills/catalyst-basics/references/cli.md
@@ -715,7 +715,11 @@ catalyst <command> --help
 ### Critical Rules
 
 - **`--production` flag warning**: Any command with `--production` targets the live production environment. Always double-check the project context before using this flag.
-- **Always confirm project before mutating**: Run `catalyst whoami` and verify the project context before running any destructive or deployment command.
+- **Always confirm project before mutating**: Run `catalyst whoami` and verify the project context before running any destructive or deployment command. Print org ID, project ID, project name, DC, component name, and target environment before deploy **or cleanup**.
+- **Timeout silent CLI**: If any `catalyst` command produces no output for ~60 seconds, stop retrying. Record `catalyst --version`, Node/runtime versions, and switch strategy.
+- **Non-interactive stdin**: In agent or CI terminals, pipe stdin closed when a command may wait for input: `catalyst deploy appsail ... </dev/null` or run from an interactive user terminal.
+- **Colima on macOS**: If Docker commands fail mysteriously, verify the active socket. For Colima: `export ZC_DOCKER_SOCK_PATH="$HOME/.colima/default/docker.sock"` (or your Colima socket path) before AppSail Docker deploy.
+- **CLI tokens ≠ REST OAuth**: Output from `catalyst token:generate` is for Catalyst CLI/automation — not a generic REST `Authorization: Bearer` token unless docs explicitly say otherwise.
 
 ---
 
@@ -737,6 +741,8 @@ catalyst <command> --help
 | Token expired | Stale auth token | Run `catalyst token:generate` or `catalyst login --force` |
 | IAC status stuck | Long-running import/export | Run `catalyst iac:status` to check progress |
 | DS import fails | Malformed CSV or schema mismatch | Verify CSV format matches table schema; run `catalyst ds:status` |
+| CLI hangs with 0% CPU, no stdout | Node/CLI pairing issue or open stdin in non-interactive terminal | Stop after ~60s; try supported Node LTS; close stdin with `</dev/null`; ask user to run manually if hang persists |
+| AppSail Docker build fails on Mac | Wrong Docker socket (Colima vs Docker Desktop) | Set `ZC_DOCKER_SOCK_PATH` to the active provider socket before deploy |
 
 ### Debugging
 

--- a/skills/catalyst-basics/references/cli.md
+++ b/skills/catalyst-basics/references/cli.md
@@ -655,6 +655,16 @@ catalyst deploy slate <name> --no-wait -ni       # Don't wait for completion
 | `-m` | Deployment message (for Slate) |
 | `--production` | Deploy to production environment (CAUTION) |
 
+### Deploy guardrails for agents
+
+- **Prefer repo deploy scripts** when present (`scripts/deploy.sh`, `Makefile` targets). Inspect them first — they may sync shared files, validate targets, or pin SDK versions before raw `catalyst deploy`.
+- **Verify deploy output lists every expected component** (Functions, Client, Slate, AppSail). Missing sections mean a partial deploy even when the CLI exits 0.
+- **Function packaging**: each function deploys as its own package. Copy shared modules into every function directory before deploy when the repo uses a sync step.
+- **Function registration**: adding a name to `catalyst.json` alone does not register a new function. The user must run `catalyst functions:add` interactively once, or follow the documented manual scaffold workaround in this file.
+- **Exact stack values**: use documented strings such as `python_3_9`, not guessed forms like `python39`.
+- **Destructive overwrite**: treat `functions:add --overwrite` and remote delete commands as destructive — require explicit user approval.
+- **Stale local execute**: when `catalyst functions:execute` runs old code, delete `functions/<name>/.build` and retry.
+
 ---
 
 ## Other Commands

--- a/skills/catalyst-datastore/references/datastore-basics.md
+++ b/skills/catalyst-datastore/references/datastore-basics.md
@@ -299,6 +299,16 @@ Data Store does NOT support multi-statement transactions.
 
 ---
 
+## Row Operation Exactness
+
+- **ROWID is a string** in SDK calls — preserve string shape; do not coerce large IDs to numbers.
+- **Use table row scopes** appropriate to the operation — do not assume a broad table scope covers row-level CRUD.
+- **Avoid reserved/system column names** in custom schemas (`ROWID`, `CREATORID`, `CREATEDTIME`, `MODIFIEDTIME` are system-managed).
+- **Bulk delete**: respect documented batch limits; pass comma-separated ROWID strings where required by the API.
+- **Smoke-test** single-row create → read → delete before bulk seed or reset scripts.
+
+---
+
 ## Concurrency Limits
 
 - Default: **10 concurrent executions** per function per environment

--- a/skills/catalyst-functions/references/functions-templates.md
+++ b/skills/catalyst-functions/references/functions-templates.md
@@ -127,6 +127,12 @@ def handler(job_request, context):
 - `context.close_with_success()` — mark job succeeded
 - `context.close_with_failure()` — mark job failed
 
+### Local test vs deployed runtime
+
+`catalyst functions:execute` does not prove deployed environment variables, scheduled timing, or Job pool behavior. Verify long-running Job logic with a remote scheduled run after local smoke tests.
+
+Clear stale build artifacts before local execute loops: `rm -rf functions/<name>/.build` when edited source does not appear in execute output.
+
 ---
 
 ## Integration Function Template

--- a/skills/catalyst-sdk/references/sdk-python.md
+++ b/skills/catalyst-sdk/references/sdk-python.md
@@ -270,3 +270,5 @@ output = smart_browz.generate_from_template(
 | Error | Cause | Fix |
 |-------|-------|-----|
 | DataStore methods hang silently in Job functions | `zcatalyst_sdk` Table methods (`get_paged_rows`, `delete_rows`, `insert_rows`, etc.) use `CredentialUser.USER` internally. Job functions have no USER token — every call makes an unauthenticated request, waits 60 s per attempt, raises no exception, and silently burns toward the 15-minute timeout | Initialize with `scope='admin'`: `zcatalyst_sdk.initialize(req=context, scope='admin')` |
+| `CatalystAppError: Catalyst headers are empty` in Python Job | Incorrect scope or missing admin initialization | Verify `scope='admin'` is passed to `zcatalyst_sdk.initialize()` in Job functions |
+| Pinning mismatch after CLI scaffold | CLI may suggest a newer `zcatalyst-sdk` than the function stack supports | Pin `zcatalyst-sdk` to a version compatible with the selected Python stack (e.g. `python_3_9`) |

--- a/skills/catalyst-slate/references/slate-basics.md
+++ b/skills/catalyst-slate/references/slate-basics.md
@@ -72,6 +72,8 @@ deployment_name = "default"
 "slate": [{ "name": "my-frontend", "source": "/absolute/path/to/client" }]
 ```
 
+> ⚠️ **Verify Slate source paths before deploy.** Root path, install command, build command, and `catalyst.json` `source` must point at the directory that contains the built artifact (often `dist/`). Use repo-relative paths in documentation examples but absolute paths in local `catalyst.json` when required by the CLI. After deploy, confirm the hosted Slate URL serves fresh assets (not a stale prior build).
+
 **Step 3** — Deploy:
 ```bash
 catalyst deploy slate -m "initial deploy"


### PR DESCRIPTION
## Summary

Proposes structural agent-readiness infrastructure alongside guardrail PRs: decision tree, mental models, workflow checklists, platform limits, eval cases, and a finding-packet contributor workflow.

## Changes

- `catalyst-by-zoho/references/agent-decision-tree.md`
- `catalyst-by-zoho/references/agent-mental-models.md`
- `catalyst-by-zoho/references/agent-workflow-checklists.md`
- `catalyst-by-zoho/references/platform-limits.md`
- `evals/appsail-agent-success.json` + `evals/README.md`
- `docs/finding-packet-template.md` + example packet
- `CONTRIBUTING.md` — agent-readiness workflow section
- `catalyst-by-zoho/SKILL.md` — routing table entry for deploy/debug loops

## Why

Reference docs alone do not stop agents from picking the wrong execution context. These files give agents a load order: context → mental model → checklist → service reference.

Builds on the two guardrail PRs in this batch.