### PR TITLE
fix: route MCP setup to shared skill and document DC-specific endpoints

### DIFF
--- a/skills/catalyst-functions/SKILL.md
+++ b/skills/catalyst-functions/SKILL.md
@@ -3,7 +3,7 @@ name: catalyst-functions
 description: "Catalyst serverless functions — all 7 types (Basic I/O, Advanced I/O, Event, Cron, Job, Integration, Browser Logic), handler signatures, catalyst-config.json, Security Rules, API Gateway routing, file uploads, busboy, Express middleware, environment variables, function URL, and function testing. Trigger on 'write a function', 'catalyst function', 'API Gateway', 'Security Rules', 'function not found', 'function returns 401', 'busboy', 'middleware', 'function URL', 'environment variable in function', or any function type question. Do NOT use for persistent servers, long-running processes, WebSockets, or Docker deployments — use catalyst-appsail instead."
 compatibility: "Requires Catalyst CLI (`npm install -g zcatalyst-cli`) and Node.js v20 (recommended; v14–v18 also supported). Java functions also require JDK 8, 11, or 17. Python functions require Python 3.9."
 metadata:
-  version: "2.0.0"
+   version: "2.0.1"
 ---
 
 ## How It Works
@@ -11,26 +11,16 @@ metadata:
 1. **Establish MCP connection first — HARD STOP if not connected.**
    Check whether `CatalystbyZoho_*` tools are available in the current tool list.
    - **If available:** Run `CatalystbyZoho_List_All_Organizations` → `CatalystbyZoho_List_All_Projects` to set project context, then proceed to step 2.
-   - **If NOT available:** Do NOT write any code, scaffold any files, or run any CLI commands. Present the two options below and wait for the user to confirm `CatalystbyZoho_*` tools are visible before continuing.
+   - **If NOT available:** Do NOT write any code, scaffold any files, or run any CLI commands. Route setup to `catalyst-zoho-mcp` and wait for the user to confirm `CatalystbyZoho_*` tools are visible before continuing.
 
    ---
 
-   **To use Catalyst via AI, you need the Zoho MCP Global Server connected.**
-   Add a single URL to your AI client config, authorize once via browser, and you're done.
+   **To use Catalyst via AI, connect Zoho MCP first.**
+   Load `skills/catalyst-zoho-mcp/SKILL.md` and follow its setup flow.
+   - Option A: Global MCP Server (DC-specific endpoint)
+   - Option B: Personal MCP Server (mcp.zoho.com)
 
-   *Claude Desktop* — edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
-   ```json
-   { "mcpServers": { "catalyst-by-zoho": { "type": "streamable-http", "url": "https://catalyst.zohomcp.com/mcp/message" } } }
-   ```
-   *Cursor* — create or edit `.cursor/mcp.json` in your project root:
-   ```json
-   { "mcpServers": { "catalyst-by-zoho": { "type": "streamable-http", "url": "https://catalyst.zohomcp.com/mcp/message" } } }
-   ```
-   *GitHub Copilot (VS Code)* — create `.vscode/mcp.json` in your workspace root:
-   ```json
-   { "servers": { "catalyst-by-zoho": { "type": "http", "url": "https://catalyst.zohomcp.com/mcp/message" } } }
-   ```
-   Restart your AI client → authorize via browser when prompted → look for `CatalystbyZoho_*` tools to confirm.
+   Use `skills/catalyst-zoho-mcp/references/zoho-mcp.md` for exact client config and verification steps.
 
    ---
 

--- a/skills/catalyst-zoho-mcp/SKILL.md
+++ b/skills/catalyst-zoho-mcp/SKILL.md
@@ -3,7 +3,7 @@ name: catalyst-zoho-mcp
 description: "Catalyst Zoho MCP — manage Catalyst infrastructure (tables, buckets, cache) via CatalystbyZoho_* MCP tools using natural language. Trigger on 'Zoho MCP', 'MCP tools', 'catalyst MCP', 'CatalystbyZoho', 'create table with AI', 'MCP setup', 'MCP config', 'global MCP server', or 'infrastructure as conversation'."
 compatibility: "Requires an MCP-capable AI host: Claude Desktop, VS Code with GitHub Copilot, or Cursor."
 metadata:
-  version: "2.1.0"
+  version: "2.1.1"
 ---
 
 ## How It Works
@@ -18,7 +18,8 @@ metadata:
    > **To work with Catalyst via MCP, choose your setup path:**
    >
    > **Option A — Global MCP Server** *(recommended)*
-   > Add one URL to your AI client config, authorize once via browser, done. No console needed.
+  > Add your DC-specific URL to your AI client config, authorize once via browser, done. No console needed.
+  > US: `https://catalyst.zohomcp.com/mcp/message`, EU: `https://catalyst.zohomcp.eu/mcp/message`, IN: `https://catalyst.zohomcp.in/mcp/message`, AU: `https://catalyst.zohomcp.com.au/mcp/message`, CA: `https://catalyst.zohomcp.ca/mcp/message`, SA: `https://catalyst.zohomcp.sa/mcp/message`, JP: `https://catalyst.zohomcp.jp/mcp/message`, UAE: `https://catalyst.zohomcp.ae/mcp/message`.
    >
    > **Option B — Personal MCP Server** *(custom/team setup)*
    > Create your own server at mcp.zoho.com, select tools, get a personal URL with a token embedded.

--- a/skills/catalyst-zoho-mcp/references/zoho-mcp.md
+++ b/skills/catalyst-zoho-mcp/references/zoho-mcp.md
@@ -5,7 +5,26 @@
 
 ## Setup — Global MCP Server
 
-**Step 1 — Add this single URL to your AI client:**
+**Step 1 — Choose your Data Center (DC) URL:**
+
+The Catalyst global MCP endpoint changes by data center. Use the URL that matches your Zoho account's DC.
+
+| DC | Region | Global MCP base URL |
+|------|------|------|
+| US | United States | `https://catalyst.zohomcp.com` |
+| EU | Europe | `https://catalyst.zohomcp.eu` |
+| IN | India | `https://catalyst.zohomcp.in` |
+| AU | Australia | `https://catalyst.zohomcp.com.au` |
+| CA | Canada | `https://catalyst.zohomcp.ca` |
+| SA | Saudi Arabia | `https://catalyst.zohomcp.sa` |
+| JP | Japan | `https://catalyst.zohomcp.jp` |
+| UAE | United Arab Emirates | `https://catalyst.zohomcp.ae` |
+
+For MCP client configs, append `/mcp/message` to the base URL.
+
+**Step 2 — Add your DC-specific URL to your AI client:**
+
+Replace `<dc-base-url>` with your DC base URL from the table above.
 
 **For Claude Desktop** — edit `claude_desktop_config.json`
 (macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
@@ -16,7 +35,7 @@ Windows: `%APPDATA%\Claude\claude_desktop_config.json`):
   "mcpServers": {
     "catalyst-by-zoho": {
       "type": "streamable-http",
-      "url": "https://catalyst.zohomcp.com/mcp/message"
+      "url": "<dc-base-url>/mcp/message"
     }
   }
 }
@@ -29,7 +48,7 @@ Windows: `%APPDATA%\Claude\claude_desktop_config.json`):
   "mcpServers": {
     "catalyst-by-zoho": {
       "type": "streamable-http",
-      "url": "https://catalyst.zohomcp.com/mcp/message"
+      "url": "<dc-base-url>/mcp/message"
     }
   }
 }
@@ -42,16 +61,16 @@ Windows: `%APPDATA%\Claude\claude_desktop_config.json`):
   "servers": {
     "catalyst-by-zoho": {
       "type": "http",
-      "url": "https://catalyst.zohomcp.com/mcp/message"
+      "url": "<dc-base-url>/mcp/message"
     }
   }
 }
 ```
 
-**Step 2 — Authorize:**
+**Step 3 — Authorize:**
 Restart your AI client. It will open a browser window and prompt you to log in to your Zoho account and grant access. This happens once — the token is stored automatically by the client.
 
-**Step 3 — Verify:**
+**Step 4 — Verify:**
 Look for `CatalystbyZoho_*` tools in your client's tool list. Done.
 
 ---


### PR DESCRIPTION
- move function-skill MCP setup guidance to the shared MCP skill flow
- add data-center-specific global MCP endpoint guidance
- update MCP reference setup steps for client configuration