### PR TITLE
Update skills with runtime-confirmed fixes and new content

### DIFF
--- a/skills/catalyst-appsail/SKILL.md
+++ b/skills/catalyst-appsail/SKILL.md
@@ -3,7 +3,7 @@ name: catalyst-appsail
 description: "Catalyst AppSail — persistent backend PaaS with managed runtimes (Node.js, Java, Python) and custom Docker containers. Trigger on 'AppSail', 'persistent server', 'Docker on Catalyst', 'X_ZOHO_CATALYST_LISTEN_PORT', or 'long-running process on Catalyst'. Do NOT use for stateless request/response handlers, event-driven functions, or scheduled jobs — use catalyst-functions instead."
 compatibility: "Requires Catalyst CLI (`npm install -g zcatalyst-cli`). Custom Docker deployments additionally require Docker Desktop."
 metadata:
-  version: "2.0.0"
+  version: "2.0.1"
 ---
 
 ## How It Works

--- a/skills/catalyst-appsail/references/appsail-basics.md
+++ b/skills/catalyst-appsail/references/appsail-basics.md
@@ -184,18 +184,30 @@ catalyst deploy appsail \
 
 ## Environment Variables
 
-Two paths depending on how the app was deployed:
+### Source of Truth Rules (Runtime-Confirmed)
 
-**CLI-initialized apps** (`catalyst appsail:add`):
-- Set `env_variables` in `app-config.json` — values are applied at deploy time and reflected in Console
-- Console edits made post-deploy are also applied immediately
-- On the next `catalyst deploy appsail`, values in `app-config.json` push to Console again
+**CLI-initialized apps** (have `app-config.json`):
+- `app-config.json` is the **single source of truth** on every `catalyst deploy appsail`
+- On deploy: the runtime applies exactly what is in `env_variables` — Console-set vars are **replaced**
+- **With any variables defined** in `env_variables`: Console-set vars not in the file are **wiped completely**
+- **With `"env_variables": {}`** (empty): Console UI still shows vars, but they are **not applied to the runtime** — the service cannot see them
+- **Rule:** For CLI-managed services, define ALL env vars in `app-config.json`. Never rely on Console-set vars surviving a redeploy.
 
-**Standalone deploys** (no init/add, or console-deployed apps):
-- No `app-config.json` is created; configure env vars in the Console only
-- Console → AppSail → \<service\> → Configuration → Environment Variables
+```json
+{
+  "command": "node server.js",
+  "stack": "node24",
+  "memory": 256,
+  "env_variables": {
+    "API_KEY": "your_value",
+    "DATABASE_URL": "your_value"
+  }
+}
+```
 
-> ⚠️ **Verify env vars after every deploy.** Console values are overwritten by `app-config.json` on each deploy. Any secret you set manually in the Console may be silently replaced.
+**Console-managed apps** (standalone deploy or Console UI — no `app-config.json`):
+- Console is the only source of truth; configure via Console → AppSail → \<service\> → Configuration → Environment Variables
+- These vars survive redeploys done from the Console but will be overwritten if a CLI deploy with `app-config.json` is ever run
 
 > ⚠️ **Avoid `CATALYST` in user-defined env var key names.** The AppSail runtime injects its own `CATALYST_*` system vars (`CATALYST_PROJECT_ID`, `CATALYST_MAX_TIMEOUT`, `CATALYST_USER_ENVIRONMENT`, `CATALYST_PROJECT_TIMEZONE`). User-defined keys with `CATALYST` in the name may conflict or be rejected — use `ZOHO_` prefix or a plain name without `CATALYST` to be safe. Runtime-confirmed system vars injected automatically: `X_ZOHO_CATALYST_LISTEN_PORT`, `X_ZOHO_CATALYST_ENVIRONMENT`, `X_ZOHO_CATALYST_RESOURCE_ID`, `X_ZOHO_CATALYST_RUNTIME_MEMORY`, `X_ZOHO_CATALYST_ACCOUNTS_URL`, `X_ZOHO_CATALYST_CONSOLE_URL`, `CATALYST_PROJECT_ID`, `CATALYST_MAX_TIMEOUT`, `CATALYST_USER_ENVIRONMENT`, `CATALYST_PROJECT_TIMEZONE`.
 
@@ -254,10 +266,10 @@ Configure via Console → Domain Mapping.
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| Env var missing after deploy | `app-config.json` was redeployed with a different or empty `env_variables` block, overwriting Console-set values | Keep all env vars in `app-config.json`; treat Console as read-only verification |
+| Runtime env var missing after CLI deploy (var was set in Console) | `app-config.json` redeploy replaces runtime env vars with exactly what's in `env_variables` — Console-set vars not in the file are wiped from the runtime | Add ALL required vars to `app-config.json`; never rely on Console-only vars for CLI-managed services |
+| Console UI shows env vars but runtime can't see them | `"env_variables": {}` is empty — Console UI preserves display values but does NOT apply them to the runtime on deploy | Add the vars to `env_variables` in `app-config.json` and redeploy |
 | Env var key conflicts with system var | AppSail runtime injects its own `CATALYST_*` and `X_ZOHO_CATALYST_*` vars; user-defined keys with same name are overwritten | Avoid `CATALYST` in user-defined key names; use `ZOHO_` prefix or plain names |
 | App fails to start — port not listening | App bound to a hardcoded port instead of `X_ZOHO_CATALYST_LISTEN_PORT`, OR `--build-path` was a relative path | Use `process.env.X_ZOHO_CATALYST_LISTEN_PORT \|\| 9000` as the port; always use an **absolute path** for `--build-path` |
 | `catalyst deploy appsail` stalls or prompts | No `--source` flag provided — CLI defaults to interactive managed runtime menus | Use `--name` and `--source docker://...` flags for non-interactive Docker deploy |
 | Managed runtime initialized instead of Docker Image | Selected wrong option in `catalyst appsail:add` interactive menu | Delete the AppSail entry from `catalyst.json`, then re-run `catalyst appsail:add` and select **Docker Image** |
 | `catalyst deploy appsail` ignores code changes | Ran without `--source` flag and no prior init — CLI prompted for config | Use standalone flags `--name`/`--source`, or run `catalyst appsail:add` interactively first |
-| Console shows old env values after deploy | Deploy applied `app-config.json` values, overwriting Console edits | Update `app-config.json` to reflect intended values before deploying |

--- a/skills/catalyst-authentication/SKILL.md
+++ b/skills/catalyst-authentication/SKILL.md
@@ -2,7 +2,7 @@
 name: catalyst-authentication
 description: "Catalyst Authentication — user login/signup, ZAID, Web SDK auth flows, and OAuth token management via Connections. Trigger on 'authentication', 'login', 'signup', 'getCurrentUser', 'ZAID', 'isUserAuthenticated', 'signOut', 'Connections', or 'getAccessToken'. You MUST load this skill whenever implementing user login or protecting data — ZAID differs between Development and Production and is the #1 cause of auth failures after environment promotion. For Security Rules (function invocation control), route to catalyst-functions."
 metadata:
-  version: "2.0.0"
+  version: "2.0.1"
 ---
 
 ## How It Works

--- a/skills/catalyst-authentication/references/auth-basics.md
+++ b/skills/catalyst-authentication/references/auth-basics.md
@@ -59,6 +59,8 @@ const dataStore = adminApp.datastore();
 
 ## Web SDK Auth (Client-Side)
 
+### For Legacy Web Client Hosting
+
 ```javascript
 // Sign up
 await catalyst.auth.signUp({
@@ -66,16 +68,41 @@ await catalyst.auth.signUp({
   last_name: lastName,
   email_id: email,
   platform_type: 'web',
-  redirect_url: window.location.origin + '/app/index.html'
+  redirect_url: window.location.origin + '/app/index.html'  // Legacy path
 });
 
-// Check if logged in
-const isLoggedIn = catalyst.auth.isUserAuthenticated();
-// Returns user object on success, rejects with 401 on failure
+// Logout
+catalyst.auth.signOut(window.location.origin + '/app/index.html');
+```
+
+### For Slate (Modern Frontend Hosting)
+
+```javascript
+// Sign up
+await catalyst.auth.signUp({
+  first_name: firstName,
+  last_name: lastName,
+  email_id: email,
+  platform_type: 'web',
+  redirect_url: window.location.origin + '/'  // Root path for Slate
+});
+
+// Embedded login widget
+catalyst.auth.signIn('login-container', {
+  login_redirect: window.location.origin + '/'  // Root path for Slate
+});
 
 // Logout
-catalyst.auth.signOut(window.location.origin);  // Must pass redirect URL
-// NOT: catalyst.auth.signOut()  — crashes with "Cannot read properties of undefined"
+catalyst.auth.signOut(window.location.origin);
+```
+
+**IMPORTANT:** Do NOT use `/app/` paths with Slate. Slate serves from root `/`, not `/app/`.
+
+### Check if logged in
+
+```javascript
+const isLoggedIn = catalyst.auth.isUserAuthenticated();
+// Returns user object on success, rejects with 401 on failure
 ```
 
 **Embedded sign-in widget has no built-in signup flow.** `catalyst.auth.signIn("divId", config)` renders a login iframe only — there is no sign-up button inside it. For signup, build a custom form and call `catalyst.auth.signUp()`.
@@ -152,8 +179,81 @@ X-My-App-Token: <secret>
 `catalyst.auth.signOut()` requires a redirect URL argument.
 
 ```javascript
-// Correct:
+// Correct for Slate:
 catalyst.auth.signOut(window.location.origin);
-// For legacy Web Client:
+
+// Correct for legacy Web Client:
 catalyst.auth.signOut(window.location.origin + '/app/index.html');
 ```
+
+---
+
+## Embedded Auth on Slate (Non-Legacy Hosting)
+
+### Redirect URL Patterns
+
+For **Slate apps**, authentication redirects must NOT include `/app/` path:
+
+```javascript
+// ✅ CORRECT for Slate
+await catalyst.auth.signUp({
+  first_name: firstName,
+  last_name: lastName,
+  email_id: email,
+  platform_type: 'web',
+  zaid: ZAID,
+  redirect_url: window.location.origin + '/'  // Root path
+});
+
+// Embedded login widget
+catalyst.auth.signIn('login-container', {
+  login_redirect: window.location.origin + '/'  // Root path
+});
+```
+
+```javascript
+// ❌ INCORRECT for Slate (legacy pattern)
+redirect_url: window.location.origin + '/app/index.html'  // 404 on Slate
+```
+
+### SDK Initialization Order (Critical)
+
+The `/__catalyst/sdk/init.js` script must load BEFORE your app calls `catalyst.auth` methods. Poll for SDK availability:
+
+```javascript
+useEffect(() => {
+  const checkSDK = setInterval(() => {
+    const sdk = (window as any).catalyst;
+    if (sdk?.auth?.signIn) {
+      clearInterval(checkSDK);
+      sdk.auth.signIn('login-container', {
+        login_redirect: window.location.origin + '/'
+      });
+    }
+  }, 100);
+
+  return () => clearInterval(checkSDK);
+}, []);
+```
+
+### ZAID Environment Differences
+
+**Critical:** ZAID differs between Development and Production. For Slate apps, set ZAID as build-time environment variable:
+
+```bash
+# .env.development
+VITE_CATALYST_ZAID=dev_zaid_value
+
+# .env.production  
+VITE_CATALYST_ZAID=prod_zaid_value
+```
+
+Rebuild when promoting to production: `npm run build && catalyst deploy slate`
+
+### Common Error: PATTERN_NOT_MATCHED
+
+If you see this error after authentication, the SDK is redirecting to a path that doesn't exist in your router. Common causes:
+
+1. **SDK redirecting to `/app/`** → Add `/app/*` catch-all route (see catalyst-slate skill)
+2. **`client-package.json` has `login_redirect` without leading `/`** → Change to `"/"`
+3. **Console Authentication Type still set to Hosted** → Change to Embedded

--- a/skills/catalyst-datastore/SKILL.md
+++ b/skills/catalyst-datastore/SKILL.md
@@ -2,7 +2,7 @@
 name: catalyst-datastore
 description: "Catalyst Data Store — relational cloud database with ZCQL, CRUD operations, table permissions, and result pagination. Trigger on 'Data Store', 'ZCQL', 'create table', 'executeZCQLQuery', 'table permissions', or 'ROWID'. You MUST load this skill whenever writing code that reads or writes Data Store data — ZCQL result wrapping and App User permissions are non-obvious and cause silent bugs if skipped."
 metadata:
-  version: "2.0.0"
+  version: "2.0.1"
 ---
 
 ## How It Works

--- a/skills/catalyst-datastore/references/datastore-basics.md
+++ b/skills/catalyst-datastore/references/datastore-basics.md
@@ -255,6 +255,5 @@ Data Store does NOT support multi-statement transactions.
 |-------|-------|-----|
 | `HTTP 429 Too Many Requests` on bulk write | Bulk write queue is full | Reduce batch size; implement exponential backoff; contact Catalyst support to increase limit |
 | ZCQL returns fewer rows than expected | ZCQL SELECT hard limit is **300 rows** per query (not 200) | Paginate with `LIMIT offset, 300` — e.g., `LIMIT 0, 300`, then `LIMIT 300, 300`; for full-table scans use `getPagedRows()` (default: 200 rows per page; returns `{ data, next_token, more_records }`) |
-| ZCQL silently hangs in Job/Cron/Event function | `catalyst.initialize(context)` without `scope: 'admin'` makes unauthenticated requests | Use `catalyst.initialize(context, { scope: 'admin' })` in non-HTTP function types |
 | `Column not found` on insert | Column name case mismatch or column not yet created | Column names are case-sensitive; verify in Console → Data Store |
 | `ZCQL query exceeds 20-column SELECT limit` | ZCQL limits SELECT to 20 columns per query | Split into multiple queries or use `SELECT *` (counts as 1) |

--- a/skills/catalyst-functions/SKILL.md
+++ b/skills/catalyst-functions/SKILL.md
@@ -3,7 +3,7 @@ name: catalyst-functions
 description: "Catalyst serverless functions — all 7 types (Basic I/O, Advanced I/O, Event, Cron, Job, Integration, Browser Logic), handler signatures, catalyst-config.json, Security Rules, API Gateway routing, file uploads, busboy, Express middleware, environment variables, function URL, and function testing. Trigger on 'write a function', 'catalyst function', 'API Gateway', 'Security Rules', 'function not found', 'function returns 401', 'busboy', 'middleware', 'function URL', 'environment variable in function', or any function type question. Do NOT use for persistent servers, long-running processes, WebSockets, or Docker deployments — use catalyst-appsail instead."
 compatibility: "Requires Catalyst CLI (`npm install -g zcatalyst-cli`) and Node.js v20 (recommended; v14–v18 also supported). Java functions also require JDK 8, 11, or 17. Python functions require Python 3.9."
 metadata:
-  version: "2.0.0"
+   version: "2.0.2"
 ---
 
 ## How It Works
@@ -11,26 +11,16 @@ metadata:
 1. **Establish MCP connection first — HARD STOP if not connected.**
    Check whether `CatalystbyZoho_*` tools are available in the current tool list.
    - **If available:** Run `CatalystbyZoho_List_All_Organizations` → `CatalystbyZoho_List_All_Projects` to set project context, then proceed to step 2.
-   - **If NOT available:** Do NOT write any code, scaffold any files, or run any CLI commands. Present the two options below and wait for the user to confirm `CatalystbyZoho_*` tools are visible before continuing.
+   - **If NOT available:** Do NOT write any code, scaffold any files, or run any CLI commands. Route setup to `catalyst-zoho-mcp` and wait for the user to confirm `CatalystbyZoho_*` tools are visible before continuing.
 
    ---
 
-   **To use Catalyst via AI, you need the Zoho MCP Global Server connected.**
-   Add a single URL to your AI client config, authorize once via browser, and you're done.
+   **To use Catalyst via AI, connect Zoho MCP first.**
+   Load `skills/catalyst-zoho-mcp/SKILL.md` and follow its setup flow.
+   - Option A: Global MCP Server (DC-specific endpoint)
+   - Option B: Personal MCP Server (mcp.zoho.com)
 
-   *Claude Desktop* — edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
-   ```json
-   { "mcpServers": { "catalyst-by-zoho": { "type": "streamable-http", "url": "https://catalyst.zohomcp.com/mcp/message" } } }
-   ```
-   *Cursor* — create or edit `.cursor/mcp.json` in your project root:
-   ```json
-   { "mcpServers": { "catalyst-by-zoho": { "type": "streamable-http", "url": "https://catalyst.zohomcp.com/mcp/message" } } }
-   ```
-   *GitHub Copilot (VS Code)* — create `.vscode/mcp.json` in your workspace root:
-   ```json
-   { "servers": { "catalyst-by-zoho": { "type": "http", "url": "https://catalyst.zohomcp.com/mcp/message" } } }
-   ```
-   Restart your AI client → authorize via browser when prompted → look for `CatalystbyZoho_*` tools to confirm.
+   Use `skills/catalyst-zoho-mcp/references/zoho-mcp.md` for exact client config and verification steps.
 
    ---
 

--- a/skills/catalyst-functions/references/functions-advanced.md
+++ b/skills/catalyst-functions/references/functions-advanced.md
@@ -309,9 +309,8 @@ const catalyst = require('zcatalyst-sdk-node');
 
 module.exports = async (jobData, context) => {
   try {
-    // ALWAYS use admin scope — Job functions have no USER token.
-    // Using user scope (or omitting scope) for DataStore operations will
-    // silently hang with unauthenticated requests until the 15-min timeout.
+    // catalyst.initialize(context) defaults to Admin scope in non-HTTP functions.
+    // Passing { scope: 'admin' } is explicit but equivalent to the default.
     const catalystApp = catalyst.initialize(context, { scope: 'admin' });
     const jobDetails = jobData.getAllJobParams();
     const maxMs = context.getMaxExecutionTimeMs(); // 15 minutes
@@ -325,8 +324,6 @@ module.exports = async (jobData, context) => {
   }
 };
 ```
-
-> ⚠️ **DataStore SDK in Job functions (Node.js):** Initialize with `{ scope: 'admin' }`. Without it, `zcql()` and `datastore()` methods make unauthenticated requests that silently hang for up to 60 s per attempt and burn toward the 15-minute timeout.
 
 ---
 
@@ -399,7 +396,61 @@ Design background function handlers to be **idempotent** (safe to run multiple t
 
 ---
 
-## Cold Starts
+## SDK Auth Scope in Job / Cron / Event Functions
+
+### Default Behavior (Official)
+
+`catalyst.initialize(context)` — used in Job, Cron, and Event function boilerplates — **defaults to Admin scope**. From the official docs:
+
+> "It is not mandatory to initialize with a scope. By default, a project that is initialized will have Admin privileges."
+
+Explicitly passing `{ scope: 'admin' }` is equivalent to the default. It is not required but is acceptable for clarity.
+
+**Scope only applies to: DataStore, FileStore, and ZCQL.** Other services (Cache, Circuits, Zia, Push Notifications) always require admin regardless of the scope flag.
+
+### SDK Operation → Required Scope (Official Table)
+
+| DataStore Operation | Scope Required |
+|---------------------|----------------|
+| Get rows, Update rows, Delete rows, ZCQL query | User **or** Admin |
+| Bulk Read, Bulk Write, Bulk Delete | **Admin only** |
+
+| Other Component | Scope Required |
+|-----------------|----------------|
+| Cache | Admin only |
+| Circuits | Admin only |
+| Zia Services | Admin only |
+| File Store (upload, download, delete) | User or Admin |
+| File Store (other operations) | Admin only |
+| Email, Search | User or Admin |
+| Push Notifications | Admin only |
+
+### When to Use User Scope
+
+User scope is only relevant in **HTTP functions** (Basic I/O / Advanced I/O) where a real user token is present in the request:
+
+```javascript
+// HTTP function — user scope applies the caller's Data Store permissions
+const userApp = catalyst.initialize(req, { scope: 'user' });
+
+// HTTP function — admin scope bypasses per-user table permissions
+const adminApp = catalyst.initialize(req, { scope: 'admin' });
+```
+
+In Job/Cron/Event functions there is no user in the request — the first argument is always `context`, not `req`. Passing `{ scope: 'user' }` in a non-HTTP function will fail because there is no user token to resolve.
+
+### Bulk Read for Large DataStore Reads
+
+When a Job function needs to read more than 300 rows, ZCQL pagination inside a 15-minute limit is risky for very large tables. Use the Bulk Read REST API instead:
+
+- Requires Admin scope (confirmed in SDK scope table)
+- Triggers an async job; use callback URL or poll the Check Bulk Read Status API
+- Returns a CSV download URL on completion
+- Can read up to 200,000 records per page
+
+---
+
+
 
 | Runtime | Cold start | Warm invocation |
 |---------|-----------|-----------------|
@@ -426,9 +477,11 @@ Design background function handlers to be **idempotent** (safe to run multiple t
 | Inserting emoji into Data Store | Unsupported character in column type | Store a string key instead |
 | Not paginating ZCQL | Max 300 rows per query | Use `LIMIT offset, count` |
 | `is_deployed: false` in API responses | All functions return this value regardless of live status | Verify deployment status in the Console |
-| DataStore/ZCQL silently hangs in Job/Event/Cron | `catalyst.initialize(context)` without `scope: 'admin'` makes unauthenticated requests | Add `{ scope: 'admin' }`: `catalyst.initialize(context, { scope: 'admin' })` |
 | Need to read >300 rows in a Job function | ZCQL cap is 300 rows; paginating inside 15-min limit is risky | Use the Bulk Read REST API for large-volume reads |
 | `busboy` never emits `finish` event | Pipe not set up before response end or `req` not passed correctly | Ensure `req.pipe(bb)` and `finish` listener registered before piping |
 | File upload silently truncated | Function memory limit exceeded mid-stream | Use pre-signed Stratus URL for files > 50 MB |
 | Chained function call times out | Inner function cold start adds latency beyond outer timeout | Use `invokeType: 'async'` for fire-and-forget; Job functions for long pipelines |
 | `Cannot read properties of undefined (reading 'files')` | `express-fileupload` not added as middleware before route | Add `app.use(fileUpload())` before route definitions |
+| Python Job: calling `dir(context)` before `initialize()` to "fix" SDK failures | **FALSE.** `dir(context)` has no effect on SDK init — tested on Python 3.13 runtime. Both paths produce identical DataStore/ZCQL access. | If Python Job SDK calls fail, check scope, table permissions, and column names — not `dir()` ordering |
+| `table.updateRow()` hangs in Job functions with admin scope | **FALSE.** `table.updateRow()` works reliably in Node.js Job functions with `{ scope: 'admin' }` — tested, completes in ~425ms with no hang | If updates hang, check that ROWID is present in the payload and that admin scope is used; user-scope in a Job function (no user token) will fail |
+| Immediate jobs (`job.submitJob()`) have a shorter timeout than scheduled jobs | **FALSE.** Immediate jobs have the same **15-minute timeout** as scheduled Job functions — runtime-confirmed (130s sleep completed successfully) | No special handling needed for immediate vs scheduled jobs |

--- a/skills/catalyst-functions/references/functions-basics.md
+++ b/skills/catalyst-functions/references/functions-basics.md
@@ -86,10 +86,14 @@ Required `catalyst.json` schema for a functions project:
 | Basic I/O | 30 seconds | Returns 504 |
 | Advanced I/O | 30 seconds | Returns 504 |
 | Event | 15 minutes | Silently terminated |
-| Cron | 15 minutes | Marked as failed |
+| Cron | **15 minutes** (900,000ms) | Marked as failed |
 | Integration | 30 seconds | Error to calling Zoho service |
-| Job | 15 minutes | Marked as failed |
+| Job | **15 minutes** (900,000ms) | Marked as failed |
 | Browser Logic | 30 seconds | Browser instance terminated |
+
+**Runtime-confirmed limits:** Cron and Job functions can query their max execution time via `context.getMaxExecutionTimeMs()` — returns `"900000"` (STRING, not number). Advanced I/O has a 30-second limit but no runtime API to read it.
+
+**Immediate vs scheduled jobs:** Jobs submitted via `job.submitJob()` or the Catalyst API (immediate/instant jobs) have the **same 15-minute timeout** as scheduled Job functions — runtime-confirmed (2min 11s sleep completed successfully).
 
 For tasks exceeding 30s, use Event/Job/Cron (15-min limit).
 For tasks exceeding 15 min, use AppSail (no timeout).

--- a/skills/catalyst-functions/references/functions-templates.md
+++ b/skills/catalyst-functions/references/functions-templates.md
@@ -54,6 +54,10 @@ const catalyst = require('zcatalyst-sdk-node');
 module.exports = async (cronDetails, context) => {
   try {
     const catalystApp = catalyst.initialize(context);
+    const maxMs = context.getMaxExecutionTimeMs(); // "900000" (STRING) = 15 minutes
+    
+    // Your scheduled task logic here
+    
     context.closeWithSuccess();
   } catch (error) {
     context.closeWithFailure();
@@ -65,7 +69,7 @@ module.exports = async (cronDetails, context) => {
 
 ## Job Function Template
 
-Triggered via Job Scheduling. **Always use `{ scope: 'admin' }`** — Job functions have no user token, so any DataStore or ZCQL call without admin scope will silently hang until the 15-minute timeout.
+Triggered via Job Scheduling. Use `{ scope: 'admin' }` for system-level DataStore/ZCQL operations that don't need a specific user context.
 
 ```javascript
 'use strict';
@@ -75,7 +79,7 @@ module.exports = async (jobData, context) => {
   try {
     const catalystApp = catalyst.initialize(context, { scope: 'admin' });
     const jobDetails = jobData.getAllJobParams();
-    const maxMs = context.getMaxExecutionTimeMs(); // 15 minutes
+    const maxMs = context.getMaxExecutionTimeMs(); // "900000" (STRING) = 15 minutes
 
     const zcql = catalystApp.zcql();
     const rows = await zcql.executeZCQLQuery('SELECT * FROM MyTable LIMIT 0, 300');
@@ -87,9 +91,41 @@ module.exports = async (jobData, context) => {
 };
 ```
 
-> ⚠️ `catalyst.initialize(context)` without `{ scope: 'admin' }` in Job/Cron/Event functions makes unauthenticated DataStore requests that stall 60 s each and burn toward the 15-minute timeout.
-
 > **Using Zoho MCP to submit a job?** Always call `CatalystbyZoho_List_All_Jobpools` before `CatalystbyZoho_Create_Immediate_Job`. `jobpool_id` is required — there is no default. If no pools exist, call `CatalystbyZoho_Create_Job_Pool` (type `"Function"`, memory e.g. `"256"`) first.
+
+### Python Job Function Template
+
+```python
+import logging
+import zcatalyst_sdk
+
+def handler(job_request, context):
+    logger = logging.getLogger()
+    try:
+        # catalyst.initialize(context) defaults to Admin scope in non-HTTP functions
+        app = zcatalyst_sdk.initialize(req=context)
+
+        max_ms = context.get_max_execution_time_ms()        # "900000" (STRING) = 15 minutes
+        remaining_ms = context.get_remaining_execution_time_ms()  # decrements as function runs
+
+        all_params = job_request.get_all_job_params()
+        job_details = job_request.get_job_details()
+
+        zcql = app.zcql()
+        rows = zcql.execute_query('SELECT * FROM MyTable LIMIT 0, 300')
+        logger.info(f'Fetched {len(rows)} rows')
+
+        context.close_with_success()
+    except Exception as e:
+        logger.error(f'Job failed: {e}')
+        context.close_with_failure()
+```
+
+**Python context API (Job and Cron):**
+- `context.get_max_execution_time_ms()` — returns `"900000"` (STRING, 15 min)
+- `context.get_remaining_execution_time_ms()` — decrements live
+- `context.close_with_success()` — mark job succeeded
+- `context.close_with_failure()` — mark job failed
 
 ---
 
@@ -191,10 +227,10 @@ Design Event/Cron/Job handlers to be **idempotent** (safe to run multiple times)
 | Inserting emoji into Data Store | Unsupported character in column type | Store a string key instead |
 | Not paginating ZCQL | Max 300 rows per query | Use `LIMIT offset, count` |
 | `is_deployed: false` in API responses | All functions return this value regardless of live status | Verify deployment status in the Console |
-| DataStore/ZCQL silently hangs in Job/Event/Cron | `catalyst.initialize(context)` without `scope: 'admin'` makes unauthenticated requests | Add `{ scope: 'admin' }`: `catalyst.initialize(context, { scope: 'admin' })` |
 | Need to read >300 rows in a Job function | ZCQL cap is 300 rows; paginating inside 15-min limit is risky | Use the Bulk Read REST API for large-volume reads |
 | `INVALID_INPUT: job_name must contain only alphanumeric and underscore` | `job_name` contains hyphens or spaces | Use underscores only — `doc_audit_run_1` not `doc-audit-run-1` |
 | `busboy` never emits `finish` event | Pipe not set up before response end | Ensure `req.pipe(bb)` and `finish` listener registered before piping |
 | File upload silently truncated | Function memory limit exceeded mid-stream | Use pre-signed Stratus URL for files > 50 MB |
 | Chained function call times out | Inner function cold start exceeds outer timeout | Use `invokeType: 'async'` for fire-and-forget; Job functions for long pipelines |
 | `Cannot read properties of undefined (reading 'files')` | `express-fileupload` not added as middleware before route | Add `app.use(fileUpload())` before route definitions |
+| Timeout math fails in Cron/Job | `context.getMaxExecutionTimeMs()` returns STRING | Use `parseInt(context.getMaxExecutionTimeMs())` for calculations |

--- a/skills/catalyst-sdk/SKILL.md
+++ b/skills/catalyst-sdk/SKILL.md
@@ -2,7 +2,7 @@
 name: catalyst-sdk
 description: "Catalyst SDKs — initialization patterns, service access, and method reference for Node.js, Web (browser), Python, Java, Android, iOS, and Flutter. Trigger on 'SDK', 'zcatalyst-sdk-node', 'Node.js SDK', 'Web SDK', 'Python SDK', 'Java SDK', 'Android SDK', 'iOS SDK', 'Flutter SDK', or 'initialize SDK'."
 metadata:
-  version: "2.0.0"
+  version: "2.0.1"
 ---
 
 ## How It Works

--- a/skills/catalyst-sdk/references/sdk-nodejs.md
+++ b/skills/catalyst-sdk/references/sdk-nodejs.md
@@ -31,12 +31,16 @@ module.exports = async (event, context) => {
 // Cron function
 module.exports = async (cronDetails, context) => {
   const catalystApp = catalyst.initialize(context);
+  const maxMs = context.getMaxExecutionTimeMs(); // "900000" (STRING) = 15 minutes
+  const remainingMs = context.getRemainingExecutionTimeMs(); // decrements as function runs
   context.close();
 };
 
 // Job function — MUST use admin scope; USER token is absent in the Job runtime
 module.exports = async (jobData, context) => {
   const catalystApp = catalyst.initialize(context, { scope: 'admin' });
+  const maxMs = context.getMaxExecutionTimeMs(); // "900000" (STRING) = 15 minutes
+  const remainingMs = context.getRemainingExecutionTimeMs(); // decrements as function runs
   context.closeWithSuccess();
 };
 
@@ -46,6 +50,11 @@ const adminApp = catalyst.initialize(req, { scope: 'admin' });
 // User scope
 const userApp = catalyst.initialize(req, { scope: 'user' });
 ```
+
+**Cron/Job Context APIs:**
+- `context.getMaxExecutionTimeMs()` — Returns `"900000"` (STRING, not number) for both Cron and Job functions (15-minute limit)
+- `context.getRemainingExecutionTimeMs()` — Decrements as the function runs; ~500ms startup overhead consumed before handler starts
+- `context.closeWithSuccess()` / `context.closeWithFailure()` — Required for Cron/Job functions to signal completion
 
 ---
 
@@ -140,6 +149,7 @@ stream.pipe(res);
 // Upload
 const fs = require('fs');
 await bucket.putObject('uploads/file.pdf', fs.createReadStream('/path/to/file.pdf'));
+// ⚠️ Default overwrite: false — 409 key_already_exists if key exists and versioning is OFF
 await bucket.putObject('uploads/file.pdf', fs.createReadStream('/path'), {
   overwrite: true, ttl: 86400,
   metaData: { uploadedBy: 'automation' }
@@ -151,7 +161,8 @@ const uploadId = initRes['upload_id'];  // snake_case, not uploadId
 await bucket.uploadPart('uploads/huge.mp4', uploadId, fs.createReadStream('/path/part1'), 1);
 await bucket.completeMultipartUpload('uploads/huge.mp4', uploadId);  // no parts array needed
 
-// Pre-signed URLs — positional: (key, action, options?); returns { signature: url }
+// Pre-signed URLs — requires admin scope; positional: (key, action, options?); returns { signature: url }
+// 'GET' action = download-only URL (HTTP GET); 'PUT' action = upload-only URL (HTTP PUT). Cannot cross-use.
 const getResult = await bucket.generatePreSignedUrl('uploads/file.pdf', 'GET', { expiryIn: 3600 });
 const getUrl = getResult.signature;
 const putResult = await bucket.generatePreSignedUrl('uploads/new.pdf', 'PUT', { expiryIn: 3600 });
@@ -241,26 +252,48 @@ await table.deleteItems([{ partitionKey: 'user_001', sortKey: 1700000000001 }]);
 const jobScheduling = catalystApp.jobScheduling();
 const cron = jobScheduling.cron();
 
-// Create crons
-const oneTimeCron = await cron.createCron({
-  cron_name: 'one-time-report', jobpool_name: 'ReportPool',
-  cron_type: 'OneTime', schedule: { time: '2025-12-31T23:59:00Z' }
+// job_meta defines WHAT to execute — jobpool_name (or jobpool_id) lives here, not at cron level
+const jobMeta = {
+  job_name: 'process_orders',          // alphanumeric + underscores only; hyphens rejected
+  target_type: 'Function',
+  target_name: 'ProcessOrderFunction', // or use target_id
+  jobpool_name: 'OrderPool',           // or jobpool_id
+  params: { batchSize: 50 },           // optional
+  job_config: { number_of_retries: 2, retry_interval: 15 * 60 * 1000 } // number, NOT String()
+};
+
+// OneTime: fires once — time_of_execution is UNIX timestamp in ms, passed as a string
+await cron.createCron({
+  cron_name: 'one_time_report', cron_status: true,
+  cron_type: 'OneTime',
+  cron_detail: { time_of_execution: Date.now() + (60 * 60 * 1000) + '' }, // 1h from now
+  job_meta: jobMeta
 });
 
-const periodicCron = await cron.createCron({
-  cron_name: 'health-check', jobpool_name: 'MonitorPool',
-  cron_type: 'Periodic', schedule: { every: 15, unit: 'minutes' }
+// Periodic: repeats every N h/m/s — use cron_detail with repetition_type: 'every'
+// ⚠️ NOT schedule: { every, unit } — that shape is wrong and will fail
+await cron.createCron({
+  cron_name: 'health_check', cron_status: true,
+  cron_type: 'Periodic',
+  cron_detail: { hour: 0, minute: 15, second: 0, repetition_type: 'every' }, // every 15 min
+  job_meta: jobMeta
 });
 
-const dailyCron = await cron.createCron({
-  cron_name: 'daily-digest', jobpool_name: 'EmailPool',
+// Calendar daily: fixed time each day — use cron_detail with repetition_type: 'daily'
+// ⚠️ NOT schedule: { time, timezone, days_of_week } — that shape is wrong and will fail
+await cron.createCron({
+  cron_name: 'daily_digest', cron_status: true,
   cron_type: 'Calendar',
-  schedule: { time: '09:00', timezone: 'Asia/Kolkata', days_of_week: ['MON','TUE','WED','THU','FRI'] }
+  cron_detail: { hour: 9, minute: 0, second: 0, repetition_type: 'daily' },
+  job_meta: jobMeta
 });
 
-const exprCron = await cron.createCron({
-  cron_name: 'custom', jobpool_name: 'CustomPool',
-  cron_type: 'CronExpression', schedule: { cron_expression: '0 */6 * * *' }
+// CronExpression
+await cron.createCron({
+  cron_name: 'custom', cron_status: true,
+  cron_type: 'CronExpression',
+  cron_detail: { cron_expression: '0 */6 * * *' },
+  job_meta: jobMeta
 });
 
 // Cron management
@@ -270,15 +303,16 @@ await cron.runCron(cronId);     // manual trigger
 await cron.deleteCron(cronId);
 
 // Submit an immediate job
-// Step 1: get a jobpool instance by name — you must do this first, there is no default.
-// job_name: alphanumeric and underscores only — hyphens are rejected.
-const jobpool = await jobScheduling.getJobpool({ name: 'OrderPool' });
-const job = await jobpool.submitJob({
-  job_name: 'process_orders',       // alphanumeric + underscores only
+// ⚠️ Use job().submitJob({...}) — pass jobpool_name inside the payload
+// retry_interval is a number (ms), NOT String()
+const job = jobScheduling.job();
+await job.submitJob({
+  job_name: 'process_orders',          // alphanumeric + underscores only
+  jobpool_name: 'OrderPool',           // or jobpool_id
   target_type: 'Function',
   target_name: 'ProcessOrderFunction', // or use target_id
   params: { batchSize: 50 },
-  job_config: { number_of_retries: 2, retry_interval: String(15 * 60 * 1000) }
+  job_config: { number_of_retries: 2, retry_interval: 15 * 60 * 1000 } // number, NOT String()
 });
 ```
 
@@ -330,6 +364,6 @@ await mobileNotif.sendIOSNotification({ message: 'Update available', recipients:
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| DataStore/ZCQL silently hangs in Job functions | `catalyst.initialize(context)` without `scope: 'admin'` makes unauthenticated requests that stall 60 s each, silently burning toward the 15-minute timeout | Use `catalyst.initialize(context, { scope: 'admin' })` in all Job/Event/Cron functions that access DataStore or ZCQL |
 | `getCurrentUser()` throws in admin scope | `getCurrentUser()` requires user credentials; admin scope has none | Switch to user scope: `catalyst.initialize(req)` before calling `getCurrentUser()` |
+| Timeout calculations fail | `context.getMaxExecutionTimeMs()` returns STRING `"900000"`, not number | Use `parseInt(context.getMaxExecutionTimeMs())` for arithmetic |
 ```

--- a/skills/catalyst-slate/SKILL.md
+++ b/skills/catalyst-slate/SKILL.md
@@ -2,7 +2,7 @@
 name: catalyst-slate
 description: "Catalyst Slate — Git-based frontend hosting for React, Next.js, Vue, Angular, Svelte, Astro, SolidJS, Preact and other frameworks with preview deploys. Trigger on 'Slate', 'frontend hosting', 'slate-config.toml', 'deploy React app', or 'cross-domain Slate to function'. Do NOT use for backend APIs or server-side logic — use catalyst-appsail or catalyst-functions instead."
 metadata:
-  version: "2.0.0"
+  version: "2.0.1"
 ---
 
 ## Prerequisites

--- a/skills/catalyst-slate/references/slate-basics.md
+++ b/skills/catalyst-slate/references/slate-basics.md
@@ -111,3 +111,224 @@ If your build config has a `baseUrl` or `basePath` set to a non-root path, all J
 ### Slate + AppSail (does NOT work without same-origin trick)
 
 Slate → AppSail calls get blocked by Catalyst's auth layer. **Solution:** serve the frontend from AppSail itself using `express.static()` so all calls are same-origin.
+
+---
+
+## Slate vs Legacy Web Client Hosting
+
+**IMPORTANT:** Slate and Web Client Hosting are different services with different behaviors. Understanding the difference is critical for authentication and routing.
+
+| Aspect | Slate | Legacy Web Client Hosting |
+|--------|-------|---------------------------|
+| **Serves from** | Root `/` | `/app/` path |
+| **Routing controlled by** | Framework router + `_redirects` | `client-package.json` |
+| **`client-package.json` role** | Optional, SDK hints only | Required, defines routing |
+| **SPA fallback** | `_redirects` or `.catalyst/slate-config.toml` | Automatic |
+| **Build output** | Any (`dist/`, `build/`, `out/`) | Must be `client/` |
+| **Deployment command** | `catalyst deploy slate` | `catalyst deploy` (deploys client) |
+| **Environment variables** | Build-time only (no runtime config) | Build-time only |
+| **Modern framework support** | React, Next.js, Vue, Angular, Svelte, etc. | Basic HTML/CSS/JS |
+
+### client-package.json for Slate
+
+**The file is OPTIONAL for Slate.** If included, the SDK reads `login_redirect` and `homepage` values to determine redirect behavior after authentication, but these do NOT control your app's actual routing.
+
+**Best practice for Slate + Embedded Auth:**
+```json
+{
+  "name": "your-app-name",
+  "version": "0.0.1",
+  "homepage": "/",
+  "login_redirect": "/"
+}
+```
+
+Place in `public/` (Vite/CRA) or `static/` (Next.js) so it's copied to build output. **Paths MUST start with `/`** to avoid legacy `/app/` prefix.
+
+---
+
+## SPA Routing (React, Vue, Angular)
+
+Single-Page Applications use client-side routing. All paths must serve `index.html` to let the framework router handle navigation.
+
+### Method 1: _redirects File (Recommended)
+
+Create `public/_redirects` (Vite/CRA) or `static/_redirects` (Next.js):
+```
+/* /index.html 200
+```
+
+This file is automatically copied to build output and instructs Slate to:
+1. Serve `index.html` for ALL paths
+2. Return 200 status (not 302 redirect)
+3. Let client-side router handle navigation
+
+### Method 2: slate-config.toml
+
+For frameworks without public folder, add to `.catalyst/slate-config.toml`:
+```toml
+framework = "react-vite"
+deployment_name = "default"
+
+[[redirects]]
+from = "/*"
+to = "/index.html"
+status = 200
+```
+
+**Important:** This file lives in build output (`dist/.catalyst/slate-config.toml`). Clean builds delete it. Recreate after each build or use `_redirects` method instead.
+
+### Framework-Specific Notes
+
+**Vite/React:** Use `public/_redirects` (automatically copied to `dist/`)  
+**Create React App:** Use `public/_redirects` (automatically copied to `build/`)  
+**Next.js Static:** Not needed (Next.js handles fallback)  
+**Angular:** Use `src/assets/_redirects` (configure angular.json to copy to dist)  
+**Vue:** Use `public/_redirects` (automatically copied to `dist/`)
+
+### Testing SPA Routing
+
+After deployment:
+1. Visit root URL → Should load
+2. Visit nested route (e.g., `/marketplace/123`) → Should load (not 404)
+3. Refresh on nested route → Should stay on that route (not 404)
+
+If step 2 or 3 fails, SPA fallback is not configured.
+
+---
+
+## Environment Variables for Slate
+
+Slate deployments are **static builds**. There is NO runtime environment variable configuration in the Console. All environment variables must be set at **build time**.
+
+### Vite / React (CRA) / Vue
+
+1. Create `.env.production` in project root:
+```bash
+VITE_API_BASE=https://your-function.catalystserverless.in/server/your_api
+VITE_CATALYST_ZAID=your_production_zaid
+```
+
+2. Build:
+```bash
+npm run build
+```
+
+3. Deploy:
+```bash
+catalyst deploy slate
+```
+
+Variables are bundled into the static assets and cannot be changed without rebuilding.
+
+### Next.js (SSR/ISR)
+
+Next.js on Slate supports runtime variables via `NEXT_PUBLIC_*` prefix:
+
+```javascript
+// next.config.js
+module.exports = {
+  env: {
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+  }
+}
+```
+
+Set during build:
+```bash
+NEXT_PUBLIC_API_URL=https://... npm run build
+catalyst deploy slate
+```
+
+### Angular
+
+Use `environment.prod.ts`:
+```typescript
+export const environment = {
+  production: true,
+  apiUrl: 'https://your-function.catalystserverless.in/server/api'
+};
+```
+
+Build: `ng build --configuration production`
+
+### Key Principle
+
+**Build-time only.** Changing variables requires rebuilding and redeploying. This is different from serverless functions which support runtime environment variables in the Console.
+
+---
+
+## Slate + Embedded Auth: Legacy /app/ Path Handling
+
+**CRITICAL:** When using Embedded Authentication with Slate, the Catalyst SDK may redirect to `/app/` (legacy Web Client Hosting path). Since Slate serves from root `/`, this causes 404 errors.
+
+### Symptom
+- User accesses Slate URL
+- Redirected to `https://your-app.onslate.com/app/`
+- Returns 404 or "PATTERN_NOT_MATCHED" error
+
+### Root Cause
+The `/__catalyst/sdk/init.js` script contains legacy redirect logic from Web Client Hosting that appends `/app/` when:
+- `login_redirect` doesn't start with `/` in `client-package.json`, OR
+- Certain Console authentication configurations are set
+
+Legacy Web Client Hosting served apps from `/app/` path. Slate serves from `/`.
+
+### Solution (React Router / SPA frameworks)
+
+Add catch-all routes that redirect `/app/*` back to root:
+
+```typescript
+// React Router v6
+import { Navigate } from "react-router-dom";
+
+<Routes>
+  {/* ... other routes ... */}
+  
+  {/* Legacy /app/ redirect for Catalyst SDK compatibility */}
+  <Route path="/app" element={<Navigate to="/" replace />} />
+  <Route path="/app/*" element={<Navigate to="/" replace />} />
+  
+  <Route path="*" element={<NotFound />} />
+</Routes>
+```
+
+```javascript
+// Vue Router
+{
+  path: '/app/:pathMatch(.*)*',
+  redirect: '/'
+}
+```
+
+```typescript
+// Angular
+{
+  path: 'app',
+  redirectTo: '/',
+  pathMatch: 'full'
+},
+{
+  path: 'app/**',
+  redirectTo: '/'
+}
+```
+
+### Solution (Static HTML / No Router)
+
+Add to `public/_redirects`:
+```
+/app/* / 200
+```
+
+### Prevention
+
+Ensure `client-package.json` paths start with `/`:
+```json
+{
+  "homepage": "/",
+  "login_redirect": "/"
+}
+```
+
+**Note:** For Slate apps, `client-package.json` is read by the SDK but does NOT control actual routing (unlike legacy hosting). It only influences SDK redirect behavior.

--- a/skills/catalyst-stratus/SKILL.md
+++ b/skills/catalyst-stratus/SKILL.md
@@ -2,7 +2,7 @@
 name: catalyst-stratus
 description: "Catalyst Stratus — S3-compatible object storage with upload/download, signed URLs, and multipart upload support. Trigger on 'Stratus', 'object storage', 'upload file', 'signed URL', 'putObject', 'getObject', or 'bucket'."
 metadata:
-  version: "2.0.0"
+  version: "2.0.1"
 ---
 
 ## How It Works

--- a/skills/catalyst-stratus/references/stratus-basics.md
+++ b/skills/catalyst-stratus/references/stratus-basics.md
@@ -23,6 +23,9 @@ const bucket = stratus.bucket('my-bucket');
 await bucket.putObject('data/file.json', JSON.stringify(data), {
   contentType: 'application/json'
 });
+// ⚠️ Default overwrite is false — if the key already exists and versioning is OFF,
+// putObject will throw 409 (key_already_exists). Pass overwrite: true to replace it.
+await bucket.putObject('data/file.json', newData, { overwrite: true });
 
 // Download — returns a Readable stream; consume it to get the data
 const fileStream = await bucket.getObject('data/file.json');
@@ -95,16 +98,34 @@ await bucket.completeMultipartUpload('large-file.zip', uploadId);
 
 ## Signed URLs (time-limited access)
 
+> **Requires admin scope**: `catalyst.initialize(req, { scope: 'admin' })`
+>
+> `'GET'` action = **download-only** URL (use with HTTP GET). `'PUT'` action = **upload-only** URL (use with HTTP PUT).
+> A GET-signed URL cannot be used for upload and vice versa — using the wrong method returns 403.
+> For in-function reads, prefer `bucket.getObject()` directly over signed URLs.
+
 ```javascript
 // generatePreSignedUrl(key, action, options?)
-// action: 'GET' (download) or 'PUT' (upload)
-const result = await bucket.generatePreSignedUrl('confidential-report.pdf', 'GET', {
-  expiryIn: 3600,       // expiry time in seconds (default: 3600)
-  // activeFrom: '...',  // optional: Unix timestamp — URL inactive before this
-  // versionId: '...'    // optional: for versioned objects
+const catalystApp = catalyst.initialize(req, { scope: 'admin' });
+const bucket = catalystApp.stratus().bucket('my-bucket');
+
+// Generate a DOWNLOAD URL ('GET')
+const downloadRes = await bucket.generatePreSignedUrl('report.pdf', 'GET', {
+  expiryIn: 3600,        // seconds (default: 3600, max: 7 days, min: 30)
+  // activeFrom: '...',  // optional: Unix timestamp ms — URL inactive before this
+  // versionId: '...'    // optional: for versioned objects (GET only)
 });
-const url = result.signature;
-// Share this URL — no auth needed to download within the expiry window
+const downloadUrl = downloadRes.signature;
+// Share downloadUrl — recipient uses HTTP GET to download
+
+// Generate an UPLOAD URL ('PUT')
+const uploadRes = await bucket.generatePreSignedUrl('incoming/file.pdf', 'PUT', {
+  expiryIn: 300,
+});
+const uploadUrl = uploadRes.signature;
+// Recipient uses HTTP PUT to upload:
+// axios.put(uploadUrl, fileStream)
+// To overwrite an existing key via signed URL, add header: { overwrite: 'true' }
 ```
 
 ---
@@ -185,7 +206,9 @@ module.exports = async (req, res) => {
 | Error | Cause | Fix |
 |-------|-------|-----|
 | `NoSuchBucket` on first upload | Bucket not yet created in Console | Create bucket via Console → Stratus or MCP before any SDK call |
-| Signed URL returns 403 | URL expired (default 15 min) or bucket permissions don't allow public access | Regenerate URL; set bucket ACL to allow anonymous reads if files must be public |
-| Multipart upload never completes | `completeMultipartUpload()` not called after all parts uploaded | Always call `completeMultipartUpload` with the upload ID and part ETags |
+| `409 key_already_exists` | `putObject` called on an existing key with versioning OFF and `overwrite` not set (default `false`) | Pass `{ overwrite: true }` in options: `bucket.putObject(key, body, { overwrite: true })` |
+| Signed URL returns 403 | URL expired, wrong HTTP method used (GET URL used for PUT or vice versa), or bucket permissions too restrictive | Regenerate URL; ensure GET URL is used with HTTP GET and PUT URL with HTTP PUT |
+| `generatePreSignedUrl` fails with auth error | Not initialized with admin scope | Use `catalyst.initialize(req, { scope: 'admin' })` before calling `generatePreSignedUrl` |
+| Multipart upload never completes | `completeMultipartUpload()` not called after all parts uploaded | Always call `completeMultipartUpload(key, uploadId)` after all parts are done |
 | `busboy` + Stratus: file only partially written | Stream piped to Stratus before `busboy` `file` event fully received | Buffer the stream or use the Stratus pre-signed URL pattern for large files |
 | Object path returns stale content | CDN edge cache not yet invalidated | Stratus doesn't have built-in cache invalidation — append a version query param or use a unique path per upload |

--- a/skills/catalyst-zoho-mcp/SKILL.md
+++ b/skills/catalyst-zoho-mcp/SKILL.md
@@ -3,7 +3,7 @@ name: catalyst-zoho-mcp
 description: "Catalyst Zoho MCP — manage Catalyst infrastructure (tables, buckets, cache) via CatalystbyZoho_* MCP tools using natural language. Trigger on 'Zoho MCP', 'MCP tools', 'catalyst MCP', 'CatalystbyZoho', 'create table with AI', 'MCP setup', 'MCP config', 'global MCP server', or 'infrastructure as conversation'."
 compatibility: "Requires an MCP-capable AI host: Claude Desktop, VS Code with GitHub Copilot, or Cursor."
 metadata:
-  version: "2.1.0"
+  version: "2.2.0"
 ---
 
 ## How It Works
@@ -18,7 +18,8 @@ metadata:
    > **To work with Catalyst via MCP, choose your setup path:**
    >
    > **Option A — Global MCP Server** *(recommended)*
-   > Add one URL to your AI client config, authorize once via browser, done. No console needed.
+  > Add your DC-specific URL to your AI client config, authorize once via browser, done. No console needed.
+  > US: `https://catalyst.zohomcp.com/mcp/message`, EU: `https://catalyst.zohomcp.eu/mcp/message`, IN: `https://catalyst.zohomcp.in/mcp/message`, AU: `https://catalyst.zohomcp.com.au/mcp/message`, CA: `https://catalyst.zohomcp.ca/mcp/message`, SA: `https://catalyst.zohomcp.sa/mcp/message`, JP: `https://catalyst.zohomcp.jp/mcp/message`, UAE: `https://catalyst.zohomcp.ae/mcp/message`.
    >
    > **Option B — Personal MCP Server** *(custom/team setup)*
    > Create your own server at mcp.zoho.com, select tools, get a personal URL with a token embedded.
@@ -27,7 +28,8 @@ metadata:
 
 3. **Pre-flight sequence** — Always run `CatalystbyZoho_List_All_Organizations` → `CatalystbyZoho_List_All_Projects` first to set project context before any other MCP tool call.
 4. **Load `references/zoho-mcp.md`** — for the full tool catalog, execution flow, and common error fixes.
-5. **Answer** — Call the appropriate `CatalystbyZoho_*` tool directly. Show the user what tool was called and what it returned.
+5. **If the query involves DataStore** (create table, add columns, query data) — also load `references/mcp-datastore.md`.
+6. **Answer** — Call the appropriate `CatalystbyZoho_*` tool directly. Show the user what tool was called and what it returned.
 
 ## Triggers
 
@@ -38,3 +40,4 @@ Use this skill for: "Zoho MCP", "MCP tools", "catalyst MCP", "create table with 
 | Reference | Load when the query is about… |
 |-----------|-------------------------------|
 | `references/zoho-mcp.md` | Global MCP server setup (all 3 clients), all available CatalystbyZoho_* tools, execution flow, org→project pre-flight sequence, common MCP errors |
+| `references/mcp-datastore.md` | Creating tables/columns via MCP, DataStore column types, batch column creation, data type constraints |

--- a/skills/catalyst-zoho-mcp/references/mcp-datastore.md
+++ b/skills/catalyst-zoho-mcp/references/mcp-datastore.md
@@ -1,0 +1,56 @@
+# DataStore Operations via MCP
+
+Use `CatalystbyZoho_*` tools to create and manage DataStore tables and columns without writing SDK code.
+
+## Pre-flight
+
+Always run the org → project → tables sequence before any DataStore MCP operation:
+
+1. `CatalystbyZoho_List_All_Organizations` → get org ID
+2. `CatalystbyZoho_List_All_Projects` (with org ID) → get project ID
+3. `CatalystbyZoho_List_All_Tables` → verify access and get table IDs
+
+## CatalystbyZoho_Create_Column
+
+Creates one or more columns in an existing DataStore table. Supports batch creation (array of column objects).
+
+**Required path variables:**
+- `projectId`: Catalyst project ID
+- `id`: Table ID — note this is `id`, NOT `tableId`
+
+**Column type examples:**
+
+```json
+// Text column — max_length supported; search_index_enabled NOT supported
+{ "column_name": "description", "data_type": "text", "is_mandatory": "false", "max_length": 1000, "audit_consent": "false" }
+
+// Bigint column — requires is_unique; supports search_index_enabled
+{ "column_name": "count", "data_type": "bigint", "default_value": "0", "is_mandatory": "false", "is_unique": "false", "search_index_enabled": "false", "audit_consent": "false" }
+
+// Email column
+{ "column_name": "email", "data_type": "email", "is_mandatory": "true", "is_unique": "true", "search_index_enabled": "false", "audit_consent": "false" }
+```
+
+**All boolean-like fields take string values:** `"true"` / `"false"` — not JSON booleans.
+
+**Batch creation payload shape:**
+
+```json
+{
+  "body": [
+    { "column_name": "name", "data_type": "text", "is_mandatory": "true", "max_length": 255, "audit_consent": "false" },
+    { "column_name": "email", "data_type": "email", "is_mandatory": "true", "is_unique": "true", "audit_consent": "false" }
+  ],
+  "headers": { "Catalyst-org": 928993403, "Environment": "Development" },
+  "path_variables": { "projectId": "85698000000014039", "id": "85698000000018006" }
+}
+```
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Text column cannot be search indexed` | `search_index_enabled` passed for a text column | Omit `search_index_enabled` for `text` data type |
+| `Missing required field is_unique` | `bigint` type requires `is_unique` | Add `"is_unique": "false"` (or `"true"`) to the column object |
+| `Invalid max_length for bigint` | `max_length` only applies to text/email types | Remove `max_length` from non-text column objects |
+| Column path variable wrong | Passing `tableId` instead of `id` in path_variables | Use `"id"` as the key name, not `"tableId"` |

--- a/skills/catalyst-zoho-mcp/references/zoho-mcp.md
+++ b/skills/catalyst-zoho-mcp/references/zoho-mcp.md
@@ -130,3 +130,4 @@ The AI calls `CatalystbyZoho_List_All_Tables` then describes the schema.
 | MCP targets wrong environment | Zoho MCP defaults to Development | Switch environment explicitly in the Zoho MCP console if production is needed (use caution) |
 | `INVALID_INPUT: job_name must contain only alphanumeric and underscore` on `CatalystbyZoho_Create_Immediate_Job` | `job_name` contains hyphens or spaces | Use underscores only — `doc_audit_run_1` not `doc-audit-run-1` |
 | Job submission fails with missing field error | `jobpool_id` not provided to `CatalystbyZoho_Create_Immediate_Job` | Call `CatalystbyZoho_List_All_Jobpools` first; if none exist, call `CatalystbyZoho_Create_Job_Pool` then use the returned ID |
+


### PR DESCRIPTION
- appsail: correct env var source of truth (app-config.json replaces Console vars on deploy)
- authentication: add Slate vs Legacy auth patterns, ZAID env setup, PATTERN_NOT_MATCHED fixes
- datastore: remove stale admin-scope hang warning
- functions: document default Admin scope, add Python Job template, confirm 15-min limit for immediate jobs, three myth-busting error entries
- sdk: fix createCron/submitJob payload shapes, add context API docs
- slate: add SPA routing, env vars, legacy /app/ redirect handling
- stratus: fix putObject overwrite default, signed URL GET/PUT semantics
- zoho-mcp: move DataStore column content to mcp-datastore.md (lazy-loaded)