### PR TITLE
docs(datastore, zoho-mcp): foreign key creation via MCP requires string parent IDs

### DIFF
--- a/skills/catalyst-datastore/SKILL.md
+++ b/skills/catalyst-datastore/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: catalyst-datastore
-description: "Catalyst Data Store — relational cloud database with ZCQL, CRUD operations, table permissions, and result pagination. Requires MCP connection — check for CatalystbyZoho_* tools before any operation. Trigger on 'Data Store', 'ZCQL', 'create table', 'executeZCQLQuery', 'table permissions', 'ROWID', 'boolean column', 'boolean always true', 'truthy string', 'boolean stored as string', or 'DataStore data types'. You MUST load this skill whenever writing code that reads or writes Data Store data — ZCQL result wrapping, boolean-as-string behavior, and App User permissions are non-obvious and cause silent bugs if skipped."
+description: "Catalyst Data Store — relational cloud database with ZCQL, CRUD operations, table permissions, and result pagination. Requires MCP connection — check for CatalystbyZoho_* tools before any operation. Trigger on 'Data Store', 'ZCQL', 'create table', 'executeZCQLQuery', 'table permissions', 'ROWID', 'boolean column', 'boolean always true', 'truthy string', 'boolean stored as string', 'DataStore data types', 'foreign key', 'parent_table', or 'INTERNAL_SERVER_ERROR on column creation'. You MUST load this skill whenever writing code that reads or writes Data Store data — ZCQL result wrapping, boolean-as-string behavior, and App User permissions are non-obvious and cause silent bugs if skipped."
 metadata:
   version: "2.1.0"
 ---

--- a/skills/catalyst-datastore/references/datastore-basics.md
+++ b/skills/catalyst-datastore/references/datastore-basics.md
@@ -173,7 +173,7 @@ JOINs are subject to the same 300-row result limit.
 - `text` — large text, auto max 10,000 chars
 - `int`, `bigint`, `double`, `decimal`
 - `boolean`, `date`, `datetime`
-- `foreign key` — requires `parent_table`, `parent_column`, `constraint_type`
+- `foreign key` — requires `parent_table`, `parent_column`, `constraint_type`. When creating via API or MCP tools, pass both IDs as **strings**: Catalyst IDs (~17 digits) exceed JavaScript's safe-integer limit, so numeric literals arrive rounded and creation fails with `INTERNAL_SERVER_ERROR`
 - `encrypted text` — for sensitive data; `search_index_enabled` NOT allowed
 - `text area` — for large text
 

--- a/skills/catalyst-zoho-mcp/references/mcp-datastore.md
+++ b/skills/catalyst-zoho-mcp/references/mcp-datastore.md
@@ -29,9 +29,14 @@ Creates one or more columns in an existing DataStore table. Supports batch creat
 
 // Email column
 { "column_name": "email", "data_type": "email", "is_mandatory": "true", "is_unique": "true", "search_index_enabled": "false", "audit_consent": "false" }
+
+// Foreign key column — parent_table / parent_column MUST be strings (see note below)
+{ "column_name": "owner_id", "data_type": "foreign key", "parent_table": "85698000000018006", "parent_column": "85698000000018010", "constraint_type": "ON-DELETE-CASCADE", "is_mandatory": "false", "search_index_enabled": "false", "audit_consent": "false" }
 ```
 
 **All boolean-like fields take string values:** `"true"` / `"false"` — not JSON booleans.
+
+**Foreign keys: pass `parent_table` and `parent_column` as strings.** The tool schema types them as `integer`, but Catalyst IDs (~17 digits) exceed JavaScript's safe-integer limit (2^53). A numeric JSON literal passes through a double and arrives rounded (e.g. an ID ending in `…5079` reaches the API as `…5080`), which fails with `INTERNAL_SERVER_ERROR`. The same IDs sent as quoted strings succeed. `parent_column` is the parent table's `ROWID` column ID from `CatalystbyZoho_List_All_Columns`.
 
 **Batch creation payload shape:**
 
@@ -54,3 +59,4 @@ Creates one or more columns in an existing DataStore table. Supports batch creat
 | `Missing required field is_unique` | `bigint` type requires `is_unique` | Add `"is_unique": "false"` (or `"true"`) to the column object |
 | `Invalid max_length for bigint` | `max_length` only applies to text/email types | Remove `max_length` from non-text column objects |
 | Column path variable wrong | Passing `tableId` instead of `id` in path_variables | Use `"id"` as the key name, not `"tableId"` |
+| `INTERNAL_SERVER_ERROR` on foreign key creation | Numeric `parent_table`/`parent_column` IDs rounded in transit (exceed 2^53) | Pass both IDs as quoted strings |


### PR DESCRIPTION
## Summary

Documents a foreign key creation failure mode with no current coverage: `CatalystbyZoho_Create_Column` FK creation fails with `INTERNAL_SERVER_ERROR` when `parent_table` / `parent_column` are sent as numbers. The tool schema types them as `integer`, but Catalyst IDs (~17 digits) exceed JavaScript's safe-integer limit (2^53), so numeric JSON literals are rounded in transit (verified: an ID ending `…5079` reached the API as `…5080`). The same IDs sent as quoted strings succeed.

### Changes to `catalyst-zoho-mcp/references/mcp-datastore.md`
- FK column example added to the `Create_Column` payload examples (string IDs)
- Note explaining why `parent_table` / `parent_column` must be strings, and that `parent_column` is the parent's `ROWID` column ID from `List_All_Columns`
- Common Errors row: `INTERNAL_SERVER_ERROR` on FK creation → pass IDs as quoted strings

### Changes to `catalyst-datastore/references/datastore-basics.md`
- `foreign key` column type bullet extended with the string-ID constraint

### Changes to `catalyst-datastore/SKILL.md`
- Trigger keywords added: 'foreign key', 'parent_table', 'INTERNAL_SERVER_ERROR on column creation' — so the skill loads up front for FK tasks and as recovery after the error

## Testing

A/B tested per CONTRIBUTING (imported the skill, fresh sessions, same prompt asking for an FK column via MCP):
- Unpatched: agent sent numeric IDs, hit `INTERNAL_SERVER_ERROR`, only consulted the skill after a user nudge
- Patched: skill loaded up front on the new trigger keywords, agent sent string IDs, FK created on the first attempt