### PR TITLE
Job scheduling skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,10 +141,11 @@ Brief one-line intro.
 - Do not use the headings "Troubleshooting", "Gotchas", or "Known Issues" — use `## Common Errors`.
 - Do not skip the `## How It Works` section. Agents rely on it for decision flow.
 - Do not set `version: "1.0.0"` on new skills — inherit the current repo version (`2.0.0`).
+- Do not use decorative emoji in headings or prose. Only two uses are allowed: `⚠️` for inline warning callouts, and `✅`/`❌` as Yes/No cells in availability tables. Literal CLI output quoted in a code block is left verbatim.
 
 ---
 
 ## Source of truth
 
-- Public docs: https://docs.catalyst.zoho.com/en/
+- Public docs: https://docs.catalyst.zoho.com/en/llms.txt (markdown index of every docs page; append `index.md` to any page URL to fetch it as markdown)
 - This repo: https://github.com/catalystbyzoho/agent-skills

--- a/CATALYST.md
+++ b/CATALYST.md
@@ -42,8 +42,9 @@ Before starting any Catalyst task, load the most specific matching skill from `s
 | SDKs — Node.js, Web, Python, Java, Android, iOS, Flutter | `skills/catalyst-sdk/` |
 | Zia Services, QuickML — OCR, ML, AutoML predictions | `skills/catalyst-zia/` |
 | Zoho MCP — `CatalystbyZoho_*` tools, MCP setup | `skills/catalyst-zoho-mcp/` |
+| Job Scheduling — job pools, immediate jobs, crons, `submitJob`, `createCron` | `skills/catalyst-job-scheduling/` |
 
-If the skill's reference files don't contain the answer, use a site-scoped web search (`site:docs.catalyst.zoho.com <term>`) and fetch the specific page URL returned. Do NOT fabricate docs URLs — all Catalyst documentation lives under `https://docs.catalyst.zoho.com/en/`.
+If the skill's reference files don't contain the answer, use a site-scoped web search (`site:docs.catalyst.zoho.com <term>`) and fetch the specific page URL returned **with `index.md` appended** (e.g. `https://docs.catalyst.zoho.com/en/sdk/nodejs/v2/overview/index.md`) — every docs page serves a markdown version that is ~20× smaller than the HTML. The full page index is `https://docs.catalyst.zoho.com/en/llms.txt`. If the fetched content starts with `<!DOCTYPE html>`, the page does not exist — do not treat it as documentation. Do NOT fabricate docs URLs — all Catalyst documentation lives under `https://docs.catalyst.zoho.com/en/`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,10 +97,15 @@ skills/
 │   └── references/
 │       ├── zia-services.md
 │       └── quickml.md
-└── catalyst-zoho-mcp/
+├── catalyst-zoho-mcp/
+│   ├── SKILL.md
+│   └── references/
+│       └── zoho-mcp.md                   ← MCP setup (all 3 clients), tool catalog, errors
+└── catalyst-job-scheduling/
     ├── SKILL.md
     └── references/
-        └── zoho-mcp.md                   ← MCP setup (all 3 clients), tool catalog, errors
+        ├── job-scheduling-basics.md      ← pools, immediate jobs, 4 cron types, MCP + SDK payloads
+        └── job-scheduling-advanced.md    ← retries, dynamic crons, webhook targets, observability
 ```
 
 ### Guidelines

--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ These skills give AI coding agents (Claude, etc.) deep knowledge of Catalyst's p
 | SDKs (Node.js, Web, Python, Java, Android, iOS, Flutter) | `catalyst-sdk` |
 | Zia Services + QuickML (OCR, AutoML) | `catalyst-zia` |
 | Zoho MCP (`CatalystbyZoho_*` tools) | `catalyst-zoho-mcp` |
+| Job Scheduling (job pools, immediate jobs, crons) | `catalyst-job-scheduling` |
 | Project setup, CLI, environments, architecture | `catalyst-basics` |
 
 ### Also covered (via reference files, no dedicated skill)
 
-Circuits (workflows), Job Scheduling, Pipelines (CI/CD), ConvoKraft (chatbots), Logs, APM, Alerts, GitHub integration, VS Code Extension, REST APIs. These topics appear in architecture guides and SDK references — agents will find relevant guidance but won't have a dedicated step-by-step skill.
+Circuits (workflows), Pipelines (CI/CD), ConvoKraft (chatbots), Logs, APM, Alerts, GitHub integration, VS Code Extension, REST APIs. These topics appear in architecture guides and SDK references — agents will find relevant guidance but won't have a dedicated step-by-step skill.
 
 ## Installation
 

--- a/catalyst-by-zoho/SKILL.md
+++ b/catalyst-by-zoho/SKILL.md
@@ -2,7 +2,7 @@
 name: catalyst-by-zoho
 description: "Expert coding assistant for Catalyst by Zoho — Zoho's full-stack serverless cloud platform. Use for any question about Catalyst services, CLI, SDKs, architecture, pricing, or Zoho MCP tool-based infrastructure management."
 metadata:
-  version: "2.0.1"
+  version: "2.1.0"
 ---
 
 # Catalyst by Zoho — Skill Index
@@ -38,7 +38,7 @@ Use this skill for queries containing: Catalyst, zcatalyst, AppSail, Data Store,
 
 ---
 
-## 🛑 Pre-flight gate (project-mutating tasks only)
+## Pre-flight gate (project-mutating tasks only)
 
 **Step 1 — MCP check (do this before anything else for infrastructure tasks):**
 Look for `CatalystbyZoho_*` tools in your tool list.
@@ -83,7 +83,7 @@ New to Catalyst? Here's what each service does in one line:
 
 | Service | What it is |
 |---------|-----------|
-| **Functions** | Serverless functions — Basic I/O (HTTP), Advanced I/O, Event, Cron, Integration, Email Parser, Push Notification. Per-invocation billing. |
+| **Functions** | Serverless functions — Basic I/O (HTTP), Advanced I/O, Event, Cron, Job, Integration, Browser Logic. Per-invocation billing. |
 | **AppSail** | PaaS for long-running web apps — Node.js, Java, Python managed runtimes, or any Docker container. |
 | **Data Store** | Relational tables (rows + columns, foreign keys). Queried via ZCQL (SQL-like) or SDK. |
 | **Stratus** | Object/file storage (like S3). Buckets, folders, objects. Up to 250 GB per object. |
@@ -96,7 +96,7 @@ New to Catalyst? Here's what each service does in one line:
 | **QuickML** | AutoML — train models on your own data without writing ML code. *(Not in EU/AU/IN/JP/SA/CA)* |
 | **Circuits** | Serverless workflow orchestration (step functions). *(Not in EU/AU/IN/JP/SA/CA)* |
 | **Signals** | Event-driven triggers / pub-sub (replaces legacy Event Listeners). |
-| **Job Scheduling** | Recurring/scheduled function execution (replaces legacy Cron). |
+| **Job Scheduling** | Job pools + immediate jobs + crons — scheduled/background execution of Job functions, Webhooks, Circuits, AppSail (replaces legacy Cron). |
 | **Zoho MCP** | AI tool integration — lets AI agents manage Catalyst infrastructure via `CatalystbyZoho_*` tools. |
 | **ZCQL** | SQL-like query language for Data Store. `SELECT`, `INSERT`, `UPDATE`, `DELETE`. Max 300 rows per SELECT. |
 | **ZAID** | Zoho Account ID — the built-in auth identity layer. Used with Web SDK for user auth flows. |
@@ -122,13 +122,13 @@ New to Catalyst? Here's what each service does in one line:
 | Zia Services, QuickML — OCR, ML predictions, AutoML | `catalyst-zia` |
 | Signals — event-driven triggers, publish/subscribe, event listeners, custom publisher, webhook target, dispatch policy | `catalyst-signals` |
 | SmartBrowz — headless browser, Puppeteer, Playwright, Selenium, Browser Logic, PDF generation, screenshot, Browser Grid, Dataverse | `catalyst-smartbrowz` |
-| Job Scheduling — cron/scheduled execution, recurring jobs | `catalyst-basics` (load `skills/catalyst-basics/references/architecture.md` — no dedicated skill yet) |
+| Job Scheduling — job pools, immediate/background jobs, crons (Periodic/OneTime/Calendar/CronExpression), `submitJob`, `createCron`, retries | `catalyst-job-scheduling` |
 | Zoho MCP — MCP setup, `CatalystbyZoho_*` tools, infra-as-conversation | `catalyst-zoho-mcp` |
 | Skill gave wrong or outdated guidance — user reporting an error | load `catalyst-by-zoho/references/skill-feedback.md` |
 
 ---
 
-## ⛔ Never Use (deprecated + regionally restricted)
+## Never Use (deprecated + regionally restricted)
 
 ### Deprecated services — do not use for new projects
 
@@ -221,8 +221,10 @@ After `catalyst init`, a `.catalystrc` file is written to the project root. Read
 
 ## Documentation
 
-- Main docs: https://docs.catalyst.zoho.com/en/
-- Node.js SDK: https://docs.catalyst.zoho.com/en/sdk/nodejs/v2/overview/
-- Web SDK: https://docs.catalyst.zoho.com/en/sdk/web/v4/overview/
-- CLI reference: https://docs.catalyst.zoho.com/en/cli/v1/cli-command-reference/
+- Main docs: https://docs.catalyst.zoho.com/en/llms.txt
+- Node.js SDK: https://docs.catalyst.zoho.com/en/sdk/nodejs/v2/overview/index.md
+- Web SDK: https://docs.catalyst.zoho.com/en/sdk/web/v4/overview/index.md
+- CLI reference: https://docs.catalyst.zoho.com/en/cli/v1/cli-command-reference/index.md
 - Pricing: https://catalyst.zoho.com/pricing.html
+
+> Fetching docs: `llms.txt` is the markdown index of every page. Append `index.md` to any docs page URL to get its markdown instead of HTML. A response starting with `<!DOCTYPE html>` means the page does not exist.

--- a/catalyst-by-zoho/references/skill-feedback.md
+++ b/catalyst-by-zoho/references/skill-feedback.md
@@ -4,7 +4,7 @@ Load this file ONLY when the user reports that a skill gave incorrect or outdate
 
 ## What to Do
 
-1. **Check the official Catalyst docs.** Fetch the relevant page at https://docs.catalyst.zoho.com/en/ or use any available MCP search tools. If the docs contradict what the skill said, tell the user the correct behavior and cite the docs URL.
+1. **Check the official Catalyst docs.** Fetch the relevant page at https://docs.catalyst.zoho.com/en/llms.txt (index of all pages; append `index.md` to a page URL for markdown) or use any available MCP search tools. If the docs contradict what the skill said, tell the user the correct behavior and cite the docs URL.
 
 2. **Report the gap.** Ask the user if they'd like to open an issue at https://github.com/catalystbyzoho/agent-skills to report the incorrect guidance. Include:
    - Which skill triggered

--- a/skills/catalyst-authentication/SKILL.md
+++ b/skills/catalyst-authentication/SKILL.md
@@ -2,10 +2,10 @@
 name: catalyst-authentication
 description: "Catalyst Authentication — user login/signup, ZAID, Web SDK auth flows, OAuth token management via Connections, third-party authentication (Okta, Auth0, Duo, custom IdP), social logins (Google, Facebook, LinkedIn, Microsoft), generateCustomToken, signinWithJwt. Trigger on 'authentication', 'login', 'signup', 'getCurrentUser', 'ZAID', 'isUserAuthenticated', 'signOut', 'Connections', 'getAccessToken', 'third-party auth', 'social login', 'Google login', 'signinWithJwt', or 'generateCustomToken'. You MUST load this skill whenever implementing user login or protecting data — ZAID differs between Development and Production and is the #1 cause of auth failures after environment promotion. For Security Rules (function invocation control), route to catalyst-functions."
 metadata:
-  version: "2.1.1"
+  version: "2.1.2"
 ---
 
-## 🚦 Local auth requires plain `catalyst serve`
+## Local auth requires plain `catalyst serve`
 
 Auth works locally only when served through `catalyst serve`. NEVER use the native dev server (`npm run dev`, `vite`, `next dev`, `ng serve`, etc.) for auth development — the Catalyst auth middleware, cookie injection, and `/__catalyst/sdk/init.js` are only available through `catalyst serve`.
 

--- a/skills/catalyst-basics/SKILL.md
+++ b/skills/catalyst-basics/SKILL.md
@@ -2,7 +2,7 @@
 name: catalyst-basics
 description: "Core Catalyst project setup — directory structure, environments, CLI commands, and all Catalyst IDs (Project ID, ZAID, Table ID, Segment ID, Org ID). Trigger on 'start a Catalyst project', 'what is .catalystrc', 'where do I find my Table ID', 'difference between Development and Production', or any Catalyst ID or CLI question."
 metadata:
-  version: "2.0.0"
+  version: "2.0.1"
 ---
 
 > **⚠️ PRE-FLIGHT CHECK:** Before creating any project files, confirm that `.catalystrc` and
@@ -30,7 +30,7 @@ metadata:
 
 Use this skill for: "how do I start a Catalyst project", "what is .catalystrc", "where do I find my Table ID / ZAID / Segment ID / Project ID", "difference between Development and Production", "Catalyst project structure", "catalyst.json explained", `catalyst init`, `catalyst deploy`, `catalyst serve`, `catalyst login`, "how do I set up Catalyst with Claude", "how do I use Catalyst in Cursor", "how do I use Catalyst with GitHub Copilot", "which service should I use", "what Catalyst service for X", or any question about Catalyst IDs, environments, organizations, IDE setup, architecture decisions, or CLI subcommands.
 
-## 🔌 MCP Connection Check (Do This Before Anything Else)
+## MCP Connection Check (Do This Before Anything Else)
 
 **Before reading `.catalystrc`, asking the user for IDs, or doing anything project-related — check whether Zoho MCP tools are available in your tool list.**
 

--- a/skills/catalyst-basics/references/architecture.md
+++ b/skills/catalyst-basics/references/architecture.md
@@ -53,7 +53,7 @@ Use this file when a user asks "which Catalyst service should I use for X?" or i
 | If you need… | Use | DC restriction |
 |---|---|---|
 | OCR, face detection, text analytics, object detection, barcode scanning, content moderation | **Zia Services** | US DC only for AutoML; see Never Use table |
-| Train a custom ML model on your own data | **QuickML (AutoML)** | Not available in EU, AU, IN, JP, SA, CA |
+| Train a custom ML model on your own data | **QuickML (AutoML)** | Not available in JP, SA, CA |
 | Browser automation, web scraping, PDF generation | **SmartBrowz / Browser Logic** | No DC restriction |
 
 ---
@@ -64,7 +64,7 @@ Use this file when a user asks "which Catalyst service should I use for X?" or i
 |---|---|---|
 | Trigger logic when data changes in Catalyst services | **Signals** | ~~Event Listeners~~ (deprecated) |
 | Run a function on a schedule (cron-style) | **Job Scheduling** | ~~Cron~~ (deprecated) |
-| Zoho service integration (Cliq, etc.) | **Integration Functions** | *Check DC restriction first* |
+| Zoho service integration (Cliq, etc.) | **Integration Functions** | Cliq-type: not available in EU, AU, IN, JP, SA, CA (US only). ConvoKraft-type: no DC restriction |
 
 ---
 
@@ -131,11 +131,15 @@ Before recommending Circuits, Integration Functions, AutoML, Push Notifications,
 | Service | US | EU | IN | AU | JP | SA | CA |
 |---------|----|----|----|----|----|----|-----|
 | Circuits | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Integration Functions | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| AutoML (QuickML) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Integration Functions — Cliq type | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Integration Functions — ConvoKraft type | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| AutoML (QuickML) | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | Push Notifications | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
-| Identity Scanner (Zia) | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Identity Scanner — Document Processing | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Identity Scanner — Facial Comparison API/SDK | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | All other services | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+Note: **Identity Scanner's "Facial Comparison" feature works from any DC via API/SDK** — only *testing it in the Catalyst console* is restricted to IN DC. The "Document Processing" feature (Aadhaar, PAN, etc.) is IN DC only end-to-end, API included.
 
 Source: https://docs.catalyst.zoho.com/en/
 
@@ -144,6 +148,6 @@ Source: https://docs.catalyst.zoho.com/en/
 | Error | Cause | Fix |
 |-------|-------|-----|
 | Circuits not visible in console | User is on EU/AU/IN/JP/SA/CA DC | Use function chaining or Job Scheduling instead |
-| Integration Functions grayed out | User is on EU/AU/IN/JP/SA/CA DC | Use a Basic I/O function with the Zoho API directly via Connections |
-| AutoML not available | User is on EU/AU/IN/JP/SA/CA DC | Use Zia's pre-built ML services (OCR, Text Analytics) which have no DC restriction |
+| Integration Functions grayed out | User is on a restricted DC (EU/AU/IN/JP/SA/CA) for **Cliq-type** Integration Functions | Switch to **ConvoKraft-type** (no DC restriction), or use a Basic I/O function with the Zoho API directly via Connections |
+| AutoML not available | User is on JP/SA/CA DC | Use Zia's pre-built ML services (OCR, Text Analytics) which have no DC restriction |
 | "File Store not found" error | Deprecated service accessed by pre-Aug 2025 account trying new feature | Migrate to Stratus |

--- a/skills/catalyst-basics/references/architecture.md
+++ b/skills/catalyst-basics/references/architecture.md
@@ -141,7 +141,7 @@ Before recommending Circuits, Integration Functions, AutoML, Push Notifications,
 
 Note: **Identity Scanner's "Facial Comparison" feature works from any DC via API/SDK** — only *testing it in the Catalyst console* is restricted to IN DC. The "Document Processing" feature (Aadhaar, PAN, etc.) is IN DC only end-to-end, API included.
 
-Source: https://docs.catalyst.zoho.com/en/
+Source: https://docs.catalyst.zoho.com/en/llms.txt
 
 ## Common Errors
 

--- a/skills/catalyst-basics/references/cli.md
+++ b/skills/catalyst-basics/references/cli.md
@@ -1,6 +1,6 @@
 # CLI Command Reference
 
-Complete reference for the Catalyst CLI (`catalyst` / `zcatalyst`). For official docs see: https://docs.catalyst.zoho.com/en/cli/v1/cli-command-reference/
+Complete reference for the Catalyst CLI (`catalyst` / `zcatalyst`). For official docs see: https://docs.catalyst.zoho.com/en/cli/v1/cli-command-reference/index.md
 
 ---
 
@@ -311,7 +311,7 @@ Delete a function.
 
 ```bash
 catalyst functions:delete <function_name> --local      # Remove only from local project (default in NI mode)
-catalyst functions:delete <function_name> --remote     # ⛔ BLOCKED in NI mode — delete locally only
+catalyst functions:delete <function_name> --remote     # BLOCKED in NI mode — delete locally only
 ```
 
 > **NI mode:** `<function_name>` positional argument is required in non-interactive mode — omitting it falls back to an interactive selector.
@@ -332,7 +332,7 @@ Delete the client component.
 
 ```bash
 catalyst client:delete --local     # Remove only from local project (default in NI mode)
-catalyst client:delete --remote    # ⛔ BLOCKED in NI mode — delete locally only
+catalyst client:delete --remote    # BLOCKED in NI mode — delete locally only
 ```
 
 > **NI mode caveat:** `client:delete --local` may still prompt interactively in some CLI versions despite `-ni`. If it does, manually remove the client entry from `catalyst.json` → `client.targets` array and delete the local client directory instead.
@@ -811,4 +811,4 @@ Always follow this order when building a Catalyst project:
 
 ---
 
-External documentation: https://docs.catalyst.zoho.com/en/cli/v1/cli-command-reference/
+External documentation: https://docs.catalyst.zoho.com/en/cli/v1/cli-command-reference/index.md

--- a/skills/catalyst-basics/references/console-ui-guide.md
+++ b/skills/catalyst-basics/references/console-ui-guide.md
@@ -2,7 +2,7 @@
 
 Step-by-step navigation for the most common console tasks.
 
-> **Coverage note:** This guide documents the most commonly needed console flows. The following areas are **not yet documented here** and require consulting the [official Catalyst docs](https://docs.catalyst.zoho.com):
+> **Coverage note:** This guide documents the most commonly needed console flows. The following areas are **not yet documented here** and require consulting the [official Catalyst docs](https://docs.catalyst.zoho.com/en/llms.txt) (append `index.md` to any page URL to fetch it as markdown):
 > - Hosted Authentication (OAuth providers, custom login pages)
 > - Billing activation and plan upgrades
 > - Cache segment creation (Cloud Scale → Cache → New Segment)

--- a/skills/catalyst-basics/references/project-basics.md
+++ b/skills/catalyst-basics/references/project-basics.md
@@ -192,7 +192,10 @@ const segment = catalystApp.cache().segment(SEGMENT_ID);
 
 ```javascript
 // Pool ID from Console → Job Scheduling → pool details
-const pool = catalystApp.jobScheduling().pool(POOL_ID);
+// ⚠️ There is NO .pool(POOL_ID) accessor in the Node SDK. Pools are read-only:
+const pool = await catalystApp.jobScheduling().getJobpool(POOL_ID);
+// Jobs/crons take the pool by name or id INSIDE their payload:
+//   jobScheduling().job().submitJob({ ..., jobpool_id: POOL_ID })
 ```
 
 ### Circuit ID

--- a/skills/catalyst-datastore/SKILL.md
+++ b/skills/catalyst-datastore/SKILL.md
@@ -2,10 +2,10 @@
 name: catalyst-datastore
 description: "Catalyst Data Store — relational cloud database with ZCQL, CRUD operations, table permissions, and result pagination. Requires MCP connection — check for CatalystbyZoho_* tools before any operation. Trigger on 'Data Store', 'ZCQL', 'create table', 'executeZCQLQuery', 'table permissions', 'ROWID', 'boolean column', 'boolean always true', 'truthy string', 'boolean stored as string', or 'DataStore data types'. You MUST load this skill whenever writing code that reads or writes Data Store data — ZCQL result wrapping, boolean-as-string behavior, and App User permissions are non-obvious and cause silent bugs if skipped."
 metadata:
-  version: "2.1.0"
+  version: "2.1.1"
 ---
 
-## ⚠️ PREREQUISITES — READ THIS FIRST
+## PREREQUISITES — READ THIS FIRST
 
 **Before ANY Data Store operation, you MUST verify MCP connectivity.**
 

--- a/skills/catalyst-functions/SKILL.md
+++ b/skills/catalyst-functions/SKILL.md
@@ -3,7 +3,7 @@ name: catalyst-functions
 description: "Catalyst serverless functions — all 7 types (Basic I/O, Advanced I/O, Event, Cron, Job, Integration, Browser Logic), handler signatures, catalyst-config.json, Security Rules, API Gateway routing, file uploads, busboy, Express middleware, environment variables, function URL, and function testing. Requires MCP connection — check for CatalystbyZoho_* tools before any operation. Trigger on 'write a function', 'catalyst function', 'API Gateway', 'Security Rules', 'function not found', 'function returns 401', 'busboy', 'middleware', 'function URL', 'environment variable in function', 'duplicate CORS headers', 'CORS error in browser', 'Access-Control-Allow-Origin multiple values', 'function URL 404', 'execute suffix', 'function timeout', 'function hangs', or any function type question. Do NOT use for persistent servers, long-running processes, or Docker deployments — use catalyst-appsail instead."
 compatibility: "Requires Catalyst CLI (`npm install -g zcatalyst-cli`) and Node.js v20 (recommended; v14–v18 also supported). Java functions also require JDK 8, 11, or 17. Python functions require Python 3.9."
 metadata:
-   version: "2.0.1"
+   version: "2.0.2"
 ---
 
 ## How It Works

--- a/skills/catalyst-functions/references/functions-advanced.md
+++ b/skills/catalyst-functions/references/functions-advanced.md
@@ -387,10 +387,12 @@ const connection = catalystApp.connection();
 | Basic I/O | No |
 | Advanced I/O | No |
 | Event | Yes |
-| Cron | Yes |
-| Job | Yes |
+| Cron | No — cron failures trigger Application Alerts only; the JOBS a cron submits retry per their `job_config` |
+| Job | Configurable — `job_config: { number_of_retries: 0–10, retry_interval: 60–86400 /* SECONDS */ }` at submit time. Each retry is a NEW job record linked by `parent_job_id`; the original job's record stays FAILURE (runtime-confirmed) |
 | Integration | No |
 | Browser Logic | No |
+
+For full retry semantics, see `skills/catalyst-job-scheduling/references/job-scheduling-advanced.md`.
 
 Design background function handlers to be **idempotent** (safe to run multiple times).
 

--- a/skills/catalyst-functions/references/functions-templates.md
+++ b/skills/catalyst-functions/references/functions-templates.md
@@ -133,7 +133,7 @@ def handler(job_request, context):
 
 If edited source doesn't appear in `functions:execute` output, delete the stale build cache: `rm -rf functions/<name>/.build` and re-run.
 
-Note: Job **pool** memory and **function** memory are separate settings — raising the pool size alone does not raise the function's execution memory. The job function's allocated memory must be **less than** the job pool's allocated memory, or jobs suffer dispatch delays.
+Note: Job **pool** memory and **function** memory are separate settings — raising the pool size alone does not raise the function's execution memory (jobs run at the FUNCTION's memory; the pool is a ceiling). The job function's memory must be **≤** the job pool's memory, or every submission is REJECTED at submit time with `INVALID_INPUT: The memory allocated for the Job Function is higher than the memory allocated for its associated Job Pool.` (runtime-confirmed — it is a hard error, not a dispatch delay).
 
 ---
 
@@ -200,7 +200,7 @@ const connection = catalystApp.connection();
 | Advanced I/O | No | |
 | Event | Yes | Platform retries automatically |
 | Cron | **No** | Failures trigger Application Alerts only — no automatic retry. Manual review and rerun required. |
-| Job | Configurable | Retry is set in `job_config.number_of_retries` when submitting the job (0–10 retries, min 1-min interval) |
+| Job | Configurable | `job_config: { number_of_retries: 0–10, retry_interval: 60–86400 }` at submit time — `retry_interval` is in **SECONDS** (runtime-confirmed; ms values are rejected with `retry interval should be within 60s (1 minute) to 86400s (24 hours)`). Each retry is a NEW job record linked by `parent_job_id`. |
 | Integration | No | |
 | Browser Logic | No | |
 

--- a/skills/catalyst-job-scheduling/SKILL.md
+++ b/skills/catalyst-job-scheduling/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: catalyst-job-scheduling
+description: "Catalyst Job Scheduling — job pools, immediate/background jobs, and crons (Periodic, OneTime, Calendar, CronExpression) executing Job functions, Webhooks, Circuits, AppSail. Trigger on 'job scheduling', 'job pool', 'jobpool_id', 'submit a job', 'immediate job', 'cron job', 'scheduled function', 'submitJob', 'createCron', 'retry_interval', 'time_of_execution', or errors 'not a job function', 'job_name must contain only alphanumeric'. Replaces deprecated Cron."
+metadata:
+  version: "2.0.0"
+---
+
+# Catalyst Job Scheduling
+
+Job Scheduling runs background work in three pieces: **job pools** (capacity containers), **jobs** (one execution each, submitted immediately via API/SDK/MCP), and **crons** (schedulers that submit jobs on a timetable). Every fact in this skill and its references is runtime-verified against a live Catalyst project (Aug 2026) unless marked otherwise.
+
+## PREREQUISITES — READ THIS FIRST
+
+1. **A job pool must exist before anything runs.** Fresh projects have ZERO pools and there is no default. Create one first (MCP `CatalystbyZoho_Create_Job_Pool`, console, or CLI-deployed config).
+2. **Function targets must be JOB-type functions** (`catalyst functions:add --type job`). Targeting a cron-type, basicio, or advancedio function fails with `The given function is not a job function.` Cron-TYPE functions belong to the legacy Cron component — for Job Scheduling, write JOB functions even for scheduled work.
+3. **All time values are UNIX SECONDS** (`time_of_execution`, `retry_interval`). Millisecond values are accepted silently and schedule your cron for year ~58,000 — it will never fire and nothing will warn you.
+4. **`job_name` must be 1–20 chars, alphanumeric + underscore only.** ROWID-suffixed names overflow this fast — truncate (e.g. `'dun_' + rowid.slice(-6)`).
+5. The job function's memory must be **≤ its pool's memory**, or every submission is rejected with `INVALID_INPUT`.
+
+## How It Works
+
+1. **Identify the target type**: Job function (most common), Webhook (any HTTP URL), Circuit, or AppSail. Create/verify a matching-type job pool (Function pools size by `memory` MB; the others by concurrent `number` 1–10).
+2. **One-off work → submit an immediate job** (MCP `CatalystbyZoho_Create_Immediate_Job` or SDK `jobScheduling().job().submitJob()`). Recurring or delayed work → create a cron (`CatalystbyZoho_Create_Cron_Job` or SDK `cron().createCron()`) choosing Periodic / OneTime / Calendar / CronExpression. Load `references/job-scheduling-basics.md` for exact payloads for both paths.
+3. **Write the Job function handler** `(jobRequest, context)`: initialize the SDK with `catalyst.initialize(context, { scope: 'admin' })`, read inputs via `jobRequest.getAllJobParams()` (all values arrive as strings), and ALWAYS end with `context.closeWithSuccess()` or `closeWithFailure()` — failure is what triggers the retry chain.
+4. **For retries, dynamic scheduling, webhook targets, or monitoring**, load `references/job-scheduling-advanced.md` — retry semantics (new job records linked by `parent_job_id`), firing behaviors (Periodic crons fire immediately on create AND update; past-dated OneTime fires instantly; OneTime auto-disables after firing), and observability traps (success/failure counters stay 0; dynamic crons are hidden from list APIs).
+5. **Verify by job records, not counters**: `CatalystbyZoho_Get_Job_By_Id` shows `job_status` (`PENDING → RUNNING → SUCCESS | FAILURE`), `execution_time`, `dispatch_delay`, `response_code`. Do not trust cron `success_count`/`failure_count` — they stay 0.
+
+## Security Checklist
+
+- **Never log `jobRequest.getJobDetails()` or `getJobMetaDetails()` wholesale** — at runtime their `headers` contain live credentials (`X-ZC-PROJECT-SECRET-KEY`, `X-ZC-Admin-Cred-Token`). Extract only the fields you need.
+- Webhook-target jobs to your own project's function URLs carry those same credential headers; treat webhook receiver logs as sensitive.
+- Job functions run with admin privileges — validate/whitelist anything you accept via `params` before using it in queries.
+- **Never store secrets in job `headers`/`params`** — `Get_Job_By_Id` / `Get_Cron_Job_By_Id` / `List_All_Crons` return them in plaintext. Never paste a raw cron/job dump into chat, issues, or logs.
+
+## Hallucination Guards
+
+- There is **no `pool(id).createCron(...)`** API in the Node SDK. Crons: `app.jobScheduling().cron()`; jobs: `app.jobScheduling().job()`; pools (read-only): `getJobpool(id)` / `getAllJobpool()`.
+- The SDK enum `CRON_TYPE.CALENDER` ("Calender") is misspelled and **rejected by the server**. Use the string `'Calendar'`.
+- `retry_interval` is NOT milliseconds. Seconds, 60–86400. `15 * 60 * 1000` is rejected.
+- Immediate jobs and scheduled jobs share the same 15-minute timeout; `context.getMaxExecutionTimeMs()` returns the STRING `"900000"` (`parseInt` before math), while `getRemainingExecutionTimeMs()` returns a number.
+
+## Triggers
+
+- "job scheduling", "job pool", "jobpool", `jobpool_id`, "create a job pool"
+- "submit a job", "immediate job", "background job", "run this function as a job", `submitJob`, `Create_Immediate_Job`
+- "cron", "cron job", "scheduled function", "schedule a function", "recurring job", `createCron`, `Create_Cron_Job`, `cron_expression`, `time_of_execution`, "Periodic", "OneTime cron", "Calendar cron"
+- "retry a job", `number_of_retries`, `retry_interval`, `parent_job_id`, "dunning", "billing schedule", "trial expiry job"
+- `pauseCron`, `resumeCron`, `runCron`, `deleteCron`, "pause a cron", "trigger a cron manually", `Submit_Cron_Job`
+- Errors: "The given function is not a job function", "job_name must contain only alphanumeric and underscore", "job_name should be within 1-20 char length", "retry interval should be within 60s", "Delete all associated Pre-defined Crons before deleting Job Pool", "memory allocated for the Job Function is higher"
+- "webhook job", "call a URL on schedule", `notify_url`
+
+## References
+
+| File | Load when the query is about… |
+|------|-------------------------------|
+| `references/job-scheduling-basics.md` | Core concepts, job pools, immediate jobs, all 4 cron types, MCP tool workflows, Node SDK calls, Job function handler template, CLI setup |
+| `references/job-scheduling-advanced.md` | Retry semantics, dynamic (in-code) cron creation, firing/timing behaviors, webhook-target jobs, notify_url, monitoring/observability, security guardrails, pool capacity rules |

--- a/skills/catalyst-job-scheduling/references/job-scheduling-advanced.md
+++ b/skills/catalyst-job-scheduling/references/job-scheduling-advanced.md
@@ -1,0 +1,105 @@
+# Job Scheduling Advanced
+
+Retry internals, firing behaviors, dynamic scheduling from function code, webhook targets, and observability traps. All runtime-confirmed on a live project (Aug 2026) unless marked otherwise.
+
+## Retry semantics (runtime-proven)
+
+Configured per job via `job_config: { number_of_retries: 0–10, retry_interval: 60–86400 /* SECONDS */ }`.
+
+- `context.closeWithFailure()` (or an HTTP non-2xx for Webhook targets) marks the job `FAILURE` and triggers the chain.
+- **Each retry is a NEW job record** with its own `job_id`, sharing the same `job_meta_details.id`, linked by `parent_job_id` = the original job's id. Observed timeline with `retry_interval: 60`: fail at T, retry at T+61s, retry at T+122s — wall-clock-accurate seconds.
+- **Polling the ORIGINAL job id never shows retries** — it stays `FAILURE` with `retried_count: 0`. Discover retries via the console job list or your own telemetry keyed on business ids.
+- Total executions = 1 + `number_of_retries`; the chain stops early on the first success.
+- Inside the handler, `X-ZC-Request-Uuid` (in job details headers) = the CURRENT execution's job id; `retried_count` is unreliable (`null`) at runtime.
+- Crons themselves don't retry; retries apply to the JOBS a cron submits (put `job_config` in the cron's `job_meta`). Design job handlers to be idempotent.
+
+## Firing behaviors (all runtime-confirmed)
+
+| Behavior | Detail |
+|----------|--------|
+| Periodic (`every`) fires immediately | On CREATE **and** on every UPDATE, then every interval anchored to that moment (small drift of seconds/cycle observed) |
+| CronExpression fires on wall-clock boundaries | `*/5 * * * *` → :00/:05/:10… in the cron's timezone |
+| OneTime with PAST timestamp | Accepted without validation, fires ~35s later |
+| OneTime after firing | Auto-disables (`cron_status` → `false`); record remains |
+| OneTime with ms timestamp | Scheduled for year ~58,000 — never fires, zero warnings |
+| Disabled crons | Skip their schedule, but `Submit_Cron_Job` / `runCron()` still work manually |
+
+## Dynamic scheduling from inside a function
+
+A job function can create crons and submit jobs at runtime (per-entity schedules — trial expiries, per-invoice retries). Runtime-confirmed pattern:
+
+```javascript
+const js = app.jobScheduling();
+for (const sub of expiringTrials) {
+  await js.cron().createCron({
+    cron_name: 'trial_expiry_' + sub.ROWID,          // cron_name is not 20-char-limited (30 chars OK)
+    cron_status: true,
+    cron_type: 'OneTime',
+    cron_detail: {
+      time_of_execution: String(Math.floor(trialEndMs / 1000)),  // SECONDS
+      timezone: 'Asia/Kolkata'
+    },
+    job_meta: {
+      job_name: 'trial_' + String(sub.ROWID).slice(-6),          // ≤ 20 chars
+      target_type: 'Function',
+      target_name: 'billing_engine',
+      jobpool_name: 'BillingPool',
+      params: { action: 'expire_trial', sub_id: String(sub.ROWID) }
+    }
+  });
+}
+```
+
+- These crons get `cron_execution_type: "dynamic"` and are **invisible to `List_All_Crons`** (which returns only `pre-defined` crons) — persist the returned `cron.id` in your Data Store if you'll ever need to pause/delete them.
+- Mark the source row (e.g. `status: 'trial_scheduled'`) so re-runs don't double-schedule — cron_name uniqueness is NOT enforced as a dedupe mechanism.
+- SDK error objects: use `err.message` / `err.code` (`String(err)` prints `[object Object]`).
+
+## Webhook-target jobs
+
+Webhook pools dispatch plain HTTP requests — `url` + `request_method` required; `headers`, `request_body` (≤5000 chars), `params` optional.
+
+- `params` are appended as the **query string** (`POST /hook?channel=webhook`); `request_body` and custom headers are delivered verbatim.
+- Success = 2xx → `response_code: "Success"`; non-2xx → `job_status: FAILURE`, `response_code: "500"` (the actual HTTP status as string) → retries per `job_config`.
+- The target URL MAY be your own project's function URL. Such calls arrive with live Catalyst credential headers (`X-ZC-PROJECT-SECRET-KEY`, admin/user cred tokens) — an Advanced I/O receiver can `catalyst.initialize(req, { scope: 'admin' })`, but treat its logs as sensitive.
+- `notify_url` (completion callback, separate from the webhook target) must be an EXTERNAL URL — pointing it at the project's own catalystserverless.com domain fails the whole submission with a bare `INTERNAL_SERVER_ERROR`. Callback payload shape: unverified.
+
+## Monitoring & observability
+
+- Job record fields (`Get_Job_By_Id` / `getJob`): `job_status` (`PENDING/RUNNING/SUCCESS/FAILURE` — uppercase), `response_code`, `execution_time` (ms), **`dispatch_delay`** (ms, queue wait — undocumented but present), `parent_job_id`, `start_time`/`end_time`/`submitted_on` (objects with `timeWithGivenTimezone` etc., NOT strings).
+- **Cron `success_count` / `failure_count` stayed 0 across all cron types despite many successful fires — do not build monitoring on them.** Write your own audit rows from the handler instead.
+- `Delete_Job` removes a finished job's record (history cleanup). `Delete_Job_Pool` requires deleting the pool's crons first (`OPERATION_NOT_ALLOWED` otherwise).
+- Immediate and scheduled jobs share the 15-min cap: `getMaxExecutionTimeMs()` → `"900000"` (STRING; `parseInt` it), `getRemainingExecutionTimeMs()` → number, ~500ms consumed before the handler starts.
+
+## Scope & security in job runtimes
+
+- The job runtime has **no user token**. `catalyst.initialize(context, { scope: 'user' })` throws at initialize: `auth/invalid_credential — no user credentials present…`. Use `{ scope: 'admin' }` (Node's default init also carries admin privileges in non-HTTP functions).
+- Never log `jobRequest.getJobDetails()` / `getJobMetaDetails()` wholesale — their `headers` carry the project secret key and admin cred tokens.
+- Job params arrive as `Record<string, string>` — parse and validate before use; the handler runs with admin data access.
+
+## CLI corner
+
+- **The CLI cannot create, list, or manage crons, jobs, or job pools** — v1.27.0 (2026-07-15) has no `cron:*`/`job:*`/`pool` commands, and updating the CLI does not add them. Its Job Scheduling involvement is only: scaffolding (`functions:add --type job`), deploying, local emulation (`functions:execute`), and sample payloads (`event:generate:job <jobpool_id>`). Manage scheduling via Console, REST, Zoho MCP tools, or the SDK.
+- `catalyst event:generate:job <jobpool_id>` prints a sample job payload matching the real runtime shape (without the id it needs an interactive TTY).
+- `catalyst functions:execute <job_fn>` emulates locally but requires the function's EXACT stack binary (node22 function + only node24 installed → "Required NodeJS version v22 is not present…"; fix with `catalyst config:set node22.bin=<path>`). Deploying has no such requirement.
+- `functions:execute` proves handler logic only — not pool behavior, schedules, or deployed env vars.
+- Stale edits in emulation? `rm -rf functions/<name>/.build`.
+
+## Not yet verified (do not present as fact)
+
+- 50-consecutive-failure auto-disable for third-party-URL crons (claimed in functions-templates.md; impractical to reproduce).
+- Circuit / AppSail target payload behavior (schema-documented only: Circuit takes `test_cases`; AppSail takes path-only `url`, `request_method`, ...).
+- `notify_url` callback body shape; cron `end_time` semantics; Calendar `monthly`/`yearly` shapes (`days`, `weeks_of_month`, `week_day`, `months`).
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Retries "not happening" when polling the job | Watching the original `job_id` — it stays `FAILURE`; retries are NEW jobs | Track `parent_job_id` linkage or use your own telemetry |
+| Periodic cron ran the moment it was created/updated | By design — `repetition_type: "every"` fires immediately on create AND update | Create disabled (`cron_status: false`) and enable at the right moment, or tolerate the first run |
+| Dynamic cron "disappeared" | `List_All_Crons` shows only pre-defined crons | `Get_Cron_Job_By_Id` with the stored id — persist ids at creation |
+| `success_count` stays 0 despite successful runs | Counters do not increment in practice | Use job records / your own audit table for monitoring |
+| `auth/invalid_credential: no user credentials present…` | `{ scope: 'user' }` in a job/cron runtime | Use `{ scope: 'admin' }` — there is no user in background runtimes |
+| `OPERATION_NOT_ALLOWED: Delete all associated Pre-defined Crons before deleting Job Pool` | Pool still referenced by crons | Delete/re-point the crons, then delete the pool |
+| Webhook job marked FAILURE with `response_code: "500"` | Target returned non-2xx | Fix the receiver or accept retries; non-2xx = failure |
+| `INTERNAL_SERVER_ERROR` submitting with `notify_url` | notify_url on the project's own domain | External URL only |
+| `getRemainingExecutionCount is not a function` etc. in a job fn | Copied cron-function template into a job function | Job: `(jobRequest, context)`; Cron: `(cronDetails, context)` — different APIs |

--- a/skills/catalyst-job-scheduling/references/job-scheduling-basics.md
+++ b/skills/catalyst-job-scheduling/references/job-scheduling-basics.md
@@ -1,0 +1,169 @@
+# Job Scheduling Basics
+
+Job pools, immediate jobs, and the four cron types — with runtime-verified payloads for the Zoho MCP tools and the Node.js SDK. All facts marked runtime-confirmed were verified on a live project (Aug 2026).
+
+## Concepts
+
+| Piece | What it is | Key rule |
+|-------|-----------|----------|
+| **Job pool** | Capacity container jobs run in | Must exist first — fresh projects have NO default pool |
+| **Job** | One execution (immediate, or submitted by a cron) | Targets: Function (job-type only), Webhook, Circuit, AppSail |
+| **Cron** | Scheduler that submits jobs | Types: `Periodic`, `OneTime`, `Calendar`, `CronExpression` |
+
+- Pool capacity: Function pools → `{"memory": "512"}` (MB: 128/256/512/1024); Webhook/Circuit/Appsail pools → `{"number": "5"}` (max concurrent, 1–10). Sent as strings, echoed back as numbers.
+- The job runs at the **function's** configured memory; the pool memory is a ceiling. Function memory > pool memory ⇒ every submission rejected: `INVALID_INPUT: The memory allocated for the Job Function is higher than the memory allocated for its associated Job Pool.` (runtime-confirmed — it is a hard error, not a "dispatch delay").
+- `job_name`: 1–20 chars, alphanumeric + underscore only (both limits runtime-confirmed).
+- Job statuses (REST, uppercase): `PENDING → RUNNING → SUCCESS | FAILURE`. The SDK's enum spellings (`Submitted/Successful/…`) do NOT match the live API.
+
+## Job function (the target)
+
+Scaffold and deploy with the CLI — job functions are the ONLY function type Job Scheduling can invoke (cron/basicio/advancedio targets are rejected with `The given function is not a job function.`):
+
+```bash
+catalyst functions:add --name billing_engine --type job --stack node22 -ni
+catalyst deploy --only functions:billing_engine -ni
+```
+
+Handler (Node.js):
+
+```javascript
+'use strict';
+const catalyst = require('zcatalyst-sdk-node');
+
+module.exports = async (jobRequest, context) => {
+  // Job runtime has NO user token — admin scope is required for data access.
+  const app = catalyst.initialize(context, { scope: 'admin' });
+  try {
+    const params = jobRequest.getAllJobParams(); // Record<string, string> — ALL values are strings
+    const batch = parseInt(params.batch || '10', 10);
+
+    const maxMs = parseInt(context.getMaxExecutionTimeMs(), 10); // "900000" STRING (15 min)
+    const remMs = context.getRemainingExecutionTimeMs();         // number (~899500 at start)
+
+    const rows = await app.zcql().executeZCQLQuery(
+      `SELECT ROWID FROM Invoices WHERE status = 'unpaid' LIMIT 0, ${batch}`
+    );
+    // ... process rows ...
+
+    context.closeWithSuccess();   // ALWAYS close — this reports SUCCESS
+  } catch (e) {
+    console.log('job failed', e.message, e.code);
+    context.closeWithFailure();   // reports FAILURE and triggers the retry chain (if configured)
+  }
+};
+```
+
+Other `jobRequest` methods: `getJobDetails()`, `getJobMetaDetails()`, `getJobCapacityAttributes()` (→ `{"memory":"256"}` strings at runtime), `getJobParam(key)`. ⚠️ `getJobDetails()`/`getJobMetaDetails()` include live credential headers — never log them wholesale.
+
+## Zoho MCP workflow (runtime-confirmed payloads)
+
+All calls need `headers: {"Catalyst-org": <orgId>, "Environment": "Development"|"Production"}` and `path_variables: {"projectId": "..."}`.
+
+**1. Pre-flight — always:** `CatalystbyZoho_List_All_Jobpools`. If empty, `CatalystbyZoho_Create_Job_Pool`:
+
+```json
+{ "name": "BillingPool", "type": "Function", "capacity": { "memory": "512" } }
+```
+
+**2. Immediate job:** `CatalystbyZoho_Create_Immediate_Job` (requires `job_name`, `target_type`, `target_id`, `jobpool_id`):
+
+```json
+{
+  "job_name": "invoice_run",
+  "target_type": "Function",
+  "target_id": "<functionId>",
+  "jobpool_id": "<poolId>",
+  "params": { "action": "generate_invoices" },
+  "job_config": { "number_of_retries": "2", "retry_interval": "60" }
+}
+```
+
+`retry_interval` is **SECONDS, 60–86400** (`retry interval should be within 60s (1 minute) to 86400s (24 hours)` otherwise). Get the function id from `CatalystbyZoho_List_All_Functions`.
+
+**3. Cron:** `CatalystbyZoho_Create_Cron_Job`. Body requires `cron_name`, `cron_type`, `cron_status`, `cron_execution_type: "pre-defined"`, `job_detail`, `job_meta` (which requires `job_name`, `target_type`, `source_type: "Cron"`, `target_id`, `jobpool_id`).
+
+The four cron types (all runtime-confirmed, including `Calendar`, which is MISSING from the MCP tool schema enum but accepted by the live API):
+
+```jsonc
+// Periodic — every N h/m/s. FIRES IMMEDIATELY on create and on every update, then every interval.
+"cron_type": "Periodic",
+"job_detail": { "hour": "0", "minute": "15", "second": "0", "repetition_type": "every", "timezone": "Asia/Kolkata" }
+
+// OneTime — fires once at time_of_execution — UNIX SECONDS, not ms!
+// A past timestamp fires immediately (~35s). A ms timestamp = year ~58000 = never fires, silently.
+"cron_type": "OneTime",
+"job_detail": { "time_of_execution": 1787900689, "timezone": "Asia/Kolkata" }
+
+// Calendar — fixed clock time; repetition_type daily | monthly | yearly
+"cron_type": "Calendar",
+"job_detail": { "hour": "9", "minute": "0", "second": "0", "repetition_type": "daily", "timezone": "Asia/Kolkata" }
+
+// CronExpression — cron_expression goes at the BODY TOP LEVEL, not inside job_detail
+"cron_type": "CronExpression",
+"cron_expression": "*/5 * * * *",
+"job_detail": { "timezone": "Asia/Kolkata" }
+```
+
+**4. Operate:** `Submit_Cron_Job` (manual trigger — works even on DISABLED crons; uses the cron's stored job_meta, params in the request body are ignored), `Update_Cron_Job_Status` (enable/disable — requires the FULL cron body, not just the flag), `Update_Cron_Job`, `Get_Cron_Job_By_Id`, `Delete_Cron_Job`, `Get_Job_By_Id`, `Delete_Job` (removes a finished job's record), `Delete_Job_Pool` (fails with `OPERATION_NOT_ALLOWED` until every cron referencing the pool is deleted first).
+
+> ⚠️ **Get/list responses echo stored secrets:** `Get_Job_By_Id`, `Get_Cron_Job_By_Id`, and `List_All_Crons` return the job_meta's stored `headers` and `params` in plaintext (runtime-confirmed — custom webhook headers are echoed verbatim). Never place auth tokens or API keys in a job's `headers`/`params` expecting privacy — anyone with read access to these tools can retrieve them. Never echo a raw cron/job dump into chat, issues, or logs; surface only non-secret fields (`cron_name`, `id`, url path, schedule, `cron_status`). (This is separate from the runtime `getJobDetails()` platform-credential leak covered in `job-scheduling-advanced.md`.)
+
+## Node SDK (zcatalyst-sdk-node)
+
+```javascript
+const js = app.jobScheduling();
+
+// Immediate job
+const job = await js.job().submitJob({
+  job_name: 'dun_012345',                    // ≤ 20 chars!
+  target_type: 'Function',
+  target_name: 'dunning_processor',          // or target_id
+  jobpool_name: 'BillingPool',               // or jobpool_id
+  params: { invoice_id: '123456000000012345' },
+  job_config: { number_of_retries: 2, retry_interval: 60 }   // SECONDS
+});
+// job.job_id, job.job_status ("PENDING"), job.execution_time, job.dispatch_delay
+
+// Cron — OneTime, time_of_execution in UNIX SECONDS as a string
+await js.cron().createCron({
+  cron_name: 'trial_expiry_52381',
+  cron_status: true,
+  cron_type: 'OneTime',
+  cron_detail: { time_of_execution: String(Math.floor(Date.now() / 1000) + 3600), timezone: 'Asia/Kolkata' },
+  job_meta: {
+    job_name: 'trial_52381',
+    target_type: 'Function',
+    target_name: 'billing_engine',
+    jobpool_name: 'BillingPool',
+    params: { action: 'generate_invoices' }
+  }
+});
+
+// Lifecycle (id or name accepted) — all runtime-confirmed from inside a deployed job function
+await js.cron().pauseCron(cronId);
+await js.cron().resumeCron(cronId);
+await js.cron().runCron(cronId);      // manual trigger; returns the submitted job's details
+await js.cron().getCron(cronId);
+await js.cron().deleteCron(cronId);
+await js.job().getJob(jobId);
+await js.getAllJobpool();             // pools are read-only in the SDK — no create/update
+```
+
+SDK-created crons get `cron_execution_type: "dynamic"` (console/REST-created ones are `"pre-defined"`). ⚠️ Dynamic crons DO NOT appear in `List_All_Crons` / console cron lists — retrieve them by id and track ids yourself.
+
+There is no `pool(id).createCron(...)` shape in the Node SDK — that shape appears in older docs and does not exist.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `job_name must contain only alphanumeric and underscore` | Hyphen/space/dot in `job_name` | Use underscores: `doc_run_1` not `doc-run-1` |
+| `job_name should be within 1-20 char length` | Name too long (ROWID suffixes overflow instantly) | Truncate: `'dun_' + rowid.slice(-6)` |
+| `The given function is not a job function.` | Cron/BasicIO/AdvancedIO function used as Function target | Create a `--type job` function; cron-TYPE functions are legacy-Cron-only |
+| `retry interval should be within 60s (1 minute) to 86400s (24 hours)` | `retry_interval` sent in ms or < 60 | Use SECONDS in [60, 86400] |
+| Job submission fails: missing `jobpool_id` | No pool exists / not passed | `List_All_Jobpools` first; create a pool if empty — there is no default |
+| `The memory allocated for the Job Function is higher than the memory allocated for its associated Job Pool.` | Function memory > pool memory | Raise pool memory or lower function memory (`catalyst functions:config`) |
+| `Mandatory parameter cron expression is missing.` | `cron_expression` nested inside `job_detail` | Put `cron_expression` at the body top level |
+| `Mandatory parameter cron_type is missing` (SDK) | Used SDK enum `CRON_TYPE.CALENDER` ("Calender") | The enum is misspelled and rejected — pass the string `'Calendar'` |
+| OneTime cron never fires, no error anywhere | `time_of_execution` given in milliseconds | Use UNIX SECONDS (`Math.floor(Date.now()/1000)`) |
+| `INTERNAL_SERVER_ERROR` on job submit with `notify_url` | `notify_url` points at the project's own catalystserverless.com domain | Use an external URL, or drop notify_url (self-domain is blocked; the error message doesn't say so) |

--- a/skills/catalyst-sdk/SKILL.md
+++ b/skills/catalyst-sdk/SKILL.md
@@ -2,7 +2,7 @@
 name: catalyst-sdk
 description: "Catalyst SDKs — initialization patterns, service access, and method reference for Node.js, Web (browser), Python, Java, Android, iOS, and Flutter. Trigger on 'SDK', 'zcatalyst-sdk-node', 'Node.js SDK', 'Web SDK', 'Python SDK', 'Java SDK', 'Android SDK', 'iOS SDK', 'Flutter SDK', or 'initialize SDK'."
 metadata:
-  version: "2.0.2"
+  version: "2.0.3"
 ---
 
 ## How It Works

--- a/skills/catalyst-sdk/references/sdk-java.md
+++ b/skills/catalyst-sdk/references/sdk-java.md
@@ -1,5 +1,5 @@
 > **Supported Java versions:** 8, 11, 17
-> **Docs:** https://docs.catalyst.zoho.com/en/sdk/java/v1/overview/
+> **Docs:** https://docs.catalyst.zoho.com/en/sdk/java/v1/overview/index.md
 
 ## Maven Setup
 

--- a/skills/catalyst-sdk/references/sdk-nodejs.md
+++ b/skills/catalyst-sdk/references/sdk-nodejs.md
@@ -256,24 +256,27 @@ const cron = jobScheduling.cron();
 
 // job_meta defines WHAT to execute — jobpool_name (or jobpool_id) lives here, not at cron level
 const jobMeta = {
-  job_name: 'process_orders',          // alphanumeric + underscores only; hyphens rejected
-  target_type: 'Function',
+  job_name: 'process_orders',          // alphanumeric + underscores only, MAX 20 CHARS; hyphens rejected
+  target_type: 'Function',             // must be a JOB-type function — cron/basicio/aio targets are rejected
   target_name: 'ProcessOrderFunction', // or use target_id
   jobpool_name: 'OrderPool',           // or jobpool_id
-  params: { batchSize: 50 },           // optional
-  job_config: { number_of_retries: 2, retry_interval: 15 * 60 * 1000 } // number, NOT String()
+  params: { batchSize: '50' },         // optional; values are delivered to the handler as strings
+  job_config: { number_of_retries: 2, retry_interval: 60 } // retry_interval in SECONDS, 60–86400 (runtime-confirmed; ms values are rejected)
 };
 
-// OneTime: fires once — time_of_execution is UNIX timestamp in ms, passed as a string
+// OneTime: fires once — time_of_execution is UNIX SECONDS as a string (runtime-confirmed).
+// ⚠️ A milliseconds value is stored without error and schedules the cron for year ~58000 — it NEVER fires.
+// ⚠️ A past timestamp fires immediately (~35s). OneTime crons auto-disable after firing.
 await cron.createCron({
   cron_name: 'one_time_report', cron_status: true,
   cron_type: 'OneTime',
-  cron_detail: { time_of_execution: Date.now() + (60 * 60 * 1000) + '' }, // 1h from now
+  cron_detail: { time_of_execution: String(Math.floor(Date.now() / 1000) + 3600), timezone: 'Asia/Kolkata' }, // 1h from now
   job_meta: jobMeta
 });
 
 // Periodic: repeats every N h/m/s — use cron_detail with repetition_type: 'every'
 // ⚠️ NOT schedule: { every, unit } — that shape is wrong and will fail
+// ⚠️ Fires IMMEDIATELY on create (and on every update), then every interval (runtime-confirmed)
 await cron.createCron({
   cron_name: 'health_check', cron_status: true,
   cron_type: 'Periodic',
@@ -282,7 +285,8 @@ await cron.createCron({
 });
 
 // Calendar daily: fixed time each day — use cron_detail with repetition_type: 'daily'
-// ⚠️ NOT schedule: { time, timezone, days_of_week } — that shape is wrong and will fail
+// ⚠️ Spelling: 'Calendar'. The SDK enum CRON_TYPE.CALENDER ("Calender") is misspelled and the
+//    server rejects it with "Mandatory parameter cron_type is missing" (runtime-confirmed).
 await cron.createCron({
   cron_name: 'daily_digest', cron_status: true,
   cron_type: 'Calendar',
@@ -290,32 +294,36 @@ await cron.createCron({
   job_meta: jobMeta
 });
 
-// CronExpression
+// CronExpression — cron_expression sits at the TOP LEVEL, not inside cron_detail
 await cron.createCron({
   cron_name: 'custom', cron_status: true,
   cron_type: 'CronExpression',
-  cron_detail: { cron_expression: '0 */6 * * *' },
+  cron_expression: '0 */6 * * *',
+  cron_detail: { timezone: 'Asia/Kolkata' },
   job_meta: jobMeta
 });
 
-// Cron management
+// Cron management (id or name accepted) — all runtime-confirmed from deployed function code
 await cron.pauseCron(cronId);
 await cron.resumeCron(cronId);
-await cron.runCron(cronId);     // manual trigger
+await cron.runCron(cronId);     // manual trigger; returns the submitted job's details. Works on disabled crons too.
 await cron.deleteCron(cronId);
+// ⚠️ SDK-created crons are cron_execution_type "dynamic" and DO NOT appear in the REST/console
+//    cron LIST (pre-defined only) — persist the returned cron.id if you'll manage it later.
 
 // Submit an immediate job
 // ⚠️ Use job().submitJob({...}) — pass jobpool_name inside the payload
-// retry_interval is a number (ms), NOT String()
 const job = jobScheduling.job();
-await job.submitJob({
-  job_name: 'process_orders',          // alphanumeric + underscores only
+const submitted = await job.submitJob({
+  job_name: 'process_orders',          // alphanumeric + underscores only, ≤ 20 chars
   jobpool_name: 'OrderPool',           // or jobpool_id
   target_type: 'Function',
   target_name: 'ProcessOrderFunction', // or use target_id
-  params: { batchSize: 50 },
-  job_config: { number_of_retries: 2, retry_interval: 15 * 60 * 1000 } // number, NOT String()
+  params: { batchSize: '50' },
+  job_config: { number_of_retries: 2, retry_interval: 60 } // SECONDS (60–86400)
 });
+// submitted.job_status: 'PENDING' → 'RUNNING' → 'SUCCESS' | 'FAILURE' (uppercase at runtime).
+// Each retry is a NEW job record linked via parent_job_id — the original job's record stays FAILURE.
 ```
 
 ---

--- a/skills/catalyst-sdk/references/sdk-python.md
+++ b/skills/catalyst-sdk/references/sdk-python.md
@@ -185,17 +185,15 @@ table.deleteItems([{"pk": "partition1", "sk": "sort1"}])
 
 ## Job Scheduling
 
-```python
-pool = catalyst_app.job_scheduling().pool(pool_id)
+> ⚠️ An earlier version of this section showed `job_scheduling().pool(pool_id).create_cron({target_function, cron_expression, ...})` — that shape does NOT exist (the equivalent Node SDK has no `pool()` accessor either; its `Jobpool` class only exposes `getJob`/`submitJob`/`deleteJob`). Do not generate it. The Python job-scheduling module's exact method names are unverified — prefer the REST API / Zoho MCP tools (`CatalystbyZoho_Create_Immediate_Job`, `CatalystbyZoho_Create_Cron_Job`), whose payloads are runtime-confirmed in `skills/catalyst-job-scheduling/references/job-scheduling-basics.md`.
 
-cron = pool.create_cron({
-    "cron_name": "daily_report",
-    "target_function": "generate_report",
-    "cron_type": "calendar",
-    "cron_expression": "0 9 * * *",
-    "params": {"report_type": "daily_summary"}
-})
-```
+Server-side semantics that apply regardless of language (all runtime-confirmed):
+
+- `job_name`: 1–20 chars, alphanumeric + underscore.
+- Function targets must be **job-type** functions.
+- `time_of_execution` (OneTime crons): UNIX **seconds** — ms values silently schedule for year ~58000 and never fire.
+- `job_config.retry_interval`: **seconds**, 60–86400; `number_of_retries`: 0–10.
+- Cron types: `Periodic`, `OneTime`, `Calendar` (capital C), `CronExpression` (with top-level `cron_expression`).
 
 ---
 

--- a/skills/catalyst-zia/SKILL.md
+++ b/skills/catalyst-zia/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: catalyst-zia
-description: "Catalyst Zia Services and QuickML — OCR, Face Analytics, Text Analytics, Object Detection, Barcode Reader, Content Moderation, and AutoML predictions. Trigger on 'Zia', 'QuickML', 'OCR', 'face detection', 'text analytics', 'AutoML', 'ML model', or 'train a model on Catalyst'. DC restrictions: Identity Scanner is IN DC only; AutoML/QuickML is not available in EU, AU, IN, JP, SA, CA data centers."
+description: "Catalyst Zia Services and QuickML — OCR, Face Analytics, Text Analytics, Object Detection, Barcode Reader, Content Moderation, and AutoML predictions. Trigger on 'Zia', 'QuickML', 'OCR', 'face detection', 'text analytics', 'AutoML', 'ML model', or 'train a model on Catalyst'. DC restrictions: Identity Scanner Document Processing is IN DC only (API included); Facial Comparison works via API from any DC (console testing is IN DC only); AutoML/QuickML is not available in JP, SA, CA data centers."
 metadata:
   version: "2.0.0"
 ---

--- a/skills/catalyst-zia/references/zia-services.md
+++ b/skills/catalyst-zia/references/zia-services.md
@@ -12,8 +12,9 @@ Pricing: Pay-per-call. Refer to the `catalyst-pricing` skill for current rates a
 
 | Service | Availability |
 |---------|-------------|
-| Identity Scanner (Facial Comparison / Aadhaar) | **IN DC only** |
-| AutoML / QuickML | **Not available** in EU, AU, IN, JP, SA, CA |
+| Identity Scanner — Document Processing (Aadhaar, PAN, etc.) | **IN DC only**, API included |
+| Identity Scanner — Facial Comparison / E-KYC (API/SDK) | All data centers — only *console testing* is restricted to IN DC |
+| AutoML / QuickML | **Not available** in JP, SA, CA |
 | All other Zia services | All data centers |
 
 ---
@@ -79,7 +80,7 @@ const faceResult = await zia.analyseFace(
   fs.createReadStream('./face.png')
 );
 
-// Facial Comparison / E-KYC (⚠️ IN DC only — part of Identity Scanner)
+// Facial Comparison / E-KYC (works from any DC via API — console testing is IN DC only)
 const compareResult = await zia.compareFace(sourceImageStream, queryImageStream);
 // { match: true/false, confidence: 0–1 }
 ```
@@ -163,4 +164,4 @@ module.exports = async (context, basicIO) => {
 | `API limit exceeded` on Zia call | Free tier Zia API call quota exhausted | Upgrade plan; cache Zia results for identical inputs to reduce repeat calls |
 | `Invalid file format` on image analysis | Unsupported MIME type sent | Supported formats: JPG, PNG, WEBP; convert before sending |
 | Zia response latency > 5s | Large image or complex document sent synchronously | For bulk processing, use a Job function + async dispatch rather than a Basic I/O function |
-| Identity Scanner or AutoML not available | DC restriction | Identity Scanner: IN DC only. AutoML/QuickML: not available in EU, AU, IN, JP, SA, CA |
+| Identity Scanner or AutoML not available | DC restriction | Identity Scanner Document Processing: IN DC only (API included). Facial Comparison: works via API from any DC, only console testing is IN DC only. AutoML/QuickML: not available in JP, SA, CA |

--- a/skills/catalyst-zoho-mcp/SKILL.md
+++ b/skills/catalyst-zoho-mcp/SKILL.md
@@ -3,14 +3,14 @@ name: catalyst-zoho-mcp
 description: "Catalyst Zoho MCP — manage Catalyst infrastructure (tables, buckets, cache) via CatalystbyZoho_* MCP tools using natural language. Trigger on 'Zoho MCP', 'MCP tools', 'catalyst MCP', 'CatalystbyZoho', 'create table with AI', 'MCP setup', 'MCP config', 'global MCP server', 'infrastructure as conversation', 'MCP first', 'avoid Catalyst console', or 'use MCP instead of console'."
 compatibility: "Requires an MCP-capable AI host: Claude Desktop, VS Code with GitHub Copilot, or Cursor."
 metadata:
-  version: "2.2.1"
+  version: "2.2.2"
 ---
 
 ## How It Works
 
 1. **Check if MCP is connected** — Look for `CatalystbyZoho_*` tools in your tool list.
 
-2. **⛔ MCP NOT connected — HARD STOP.**
+2. **MCP NOT connected — HARD STOP.**
    Do NOT write any code, create any files, or call any SDK.
    Ask the user which setup path they prefer, then load `references/zoho-mcp.md` and follow only that path.
    Do not proceed to step 3 until the user confirms `CatalystbyZoho_*` tools are visible in their client.

--- a/skills/catalyst-zoho-mcp/references/zoho-mcp.md
+++ b/skills/catalyst-zoho-mcp/references/zoho-mcp.md
@@ -114,47 +114,6 @@ Tools with no required path variables (e.g. `List_All_Organizations`, `List_All_
 
 ---
 
-## How to Call Tools Correctly
-
-**Rule: always call `ZohoMCP_getSchema` before `ZohoMCP_executeTool` for any tool you haven't called before.** Most `CatalystbyZoho_*` tools require `path_variables` (e.g. `project_id`) that are invisible without the schema — guessing the arguments causes "Mandatory path variable not present" errors.
-
-### Step 1 — Get the schema
-
-`ZohoMCP_getSchema` takes `query_params`, **not** `body`:
-
-```
-ZohoMCP_getSchema({
-  query_params: { tool_name: "CatalystbyZoho_List_All_Functions" }
-})
-```
-
-> ⚠️ Passing `body: { tool_name: "..." }` instead of `query_params` returns "tool_name is required" — this is the wrong parameter location.
-
-### Step 2 — Call the tool
-
-`ZohoMCP_executeTool` always takes a `body` with this shape:
-
-```
-ZohoMCP_executeTool({
-  body: {
-    tool_name: "CatalystbyZoho_List_All_Functions",
-    arguments: {
-      path_variables: { project_id: "31594000000127002" },
-      headers: {},
-      body: {}
-    }
-  }
-})
-```
-
-- `path_variables` — URL path segments the tool requires (get names from the schema)
-- `headers` — extra HTTP headers (usually empty `{}`)
-- `body` — request payload for POST/PUT tools (empty `{}` for GET-style tools)
-
-Tools with no required path variables (e.g. `List_All_Organizations`, `List_All_Projects`) can be called with `arguments: {}`.
-
----
-
 ## Available Tools
 
 The tools available depend on which Catalyst tools are configured in your Zoho MCP server. Confirmed tool names:
@@ -167,6 +126,10 @@ The tools available depend on which Catalyst tools are configured in your Zoho M
 | `CatalystbyZoho_List_Cache_Segments` | List all Cache segments in the project |
 | `CatalystbyZoho_List_All_Jobpools` | List all Job Scheduling pools in the project |
 | `CatalystbyZoho_Create_Job_Pool` | Create a new Job Scheduling pool |
+| `CatalystbyZoho_Create_Cron_Job` | Create a Job Scheduling cron (Periodic/Webhook) — see Common Patterns for the required webhook shape |
+| `CatalystbyZoho_List_All_Crons` | List all cron jobs — ⚠️ response includes webhook header secrets in cleartext, see note below |
+| `CatalystbyZoho_Get_Cron_Job_By_Id` | Get a single cron job — ⚠️ same header-secret exposure as `List_All_Crons` |
+| `CatalystbyZoho_Submit_Cron_Job` | Manually trigger a cron job — use as the smoke test after creating a webhook cron |
 
 | `CatalystbyZoho_List_All_Functions` | List all functions in the project — each entry includes the numeric `id` field |
 | `CatalystbyZoho_Get_Logs` | Fetch function execution logs — see usage note below |
@@ -174,6 +137,10 @@ The tools available depend on which Catalyst tools are configured in your Zoho M
 > ⚠️ **`CatalystbyZoho_Get_Logs` — `resource_list` requires the numeric function ID, not the function name.**
 > Call `CatalystbyZoho_List_All_Functions` first and use the `id` field (e.g. `"101341000000019004"`).
 > Passing the function name (e.g. `"api"`) returns `INVALID_INPUT: "For input string: \"api\""` — a leaked Java NumberFormatException, not a useful error.
+
+> ⚠️ **`CatalystbyZoho_List_All_Crons` and `CatalystbyZoho_Get_Cron_Job_By_Id` return webhook header secrets in cleartext** (e.g. a shared auth secret in `job_meta.headers`). Never echo the raw response into chat, issues, or logs.
+> - If a list/get is genuinely needed, surface only non-secret fields: `cron_name`, `id`, the `url` path, schedule, `cron_status`.
+> - Never place header secret values inside an MCP tool-call prompt either — read them from local app config at call time only.
 
 For the full catalog of available tools, check your AI client's tool list after connecting — all tools shown with the `CatalystbyZoho_` prefix are available to use.
 
@@ -276,6 +243,25 @@ The AI calls `CatalystbyZoho_List_All_Tables` then describes the schema.
 
 `jobpool_id` is a required field — there is no default or fallback. Job submission fails immediately if it is omitted.
 
+### Create a webhook cron job
+
+> "Set up a daily cron that calls my AppSail purge endpoint"
+
+**`job_name` limit is 20 characters** — stricter than, and separate from, the alphanumeric-plus-underscore rule for `Create_Immediate_Job`. `lantern_quarantine_purge` (24 chars) is rejected; `lantern_q_purge` (15 chars) works.
+
+**Clone the shape from a working webhook cron — do not guess it from the old Cloud Scale "third-party URL cron" model.** A webhook cron requires:
+- `jobpool_id` — must be a **Webhook** pool (from `CatalystbyZoho_List_All_Jobpools`, or create one first)
+- `target_type: "Webhook"`
+- `url`, `request_method`, `request_body`
+- `headers` (optional) — read secret values from local app config at call time; never hardcode or paste them into the tool-call prompt
+- `job_detail` for Periodic schedules — `timezone`, `hour`, `minute`, `repetition_type: "daily"`
+
+Guessing the legacy shape produces `jobpool Name and Id cannot be null`, timezone errors, or a bare `INTERNAL_SERVER_ERROR`.
+
+**The CLI cannot create or list crons.** `zcatalyst-cli` has no cron subcommands as of `1.27.0` (2026-07-15) — updating the CLI does not add this. MCP or Console only.
+
+**After creating, smoke-test with `CatalystbyZoho_Submit_Cron_Job`** and expect HTTP 200 from the webhook. Do not rely on `success_count` from a list call as a health signal for webhook jobs — it is not reliable.
+
 ---
 
 ## Common Errors
@@ -290,4 +276,6 @@ The AI calls `CatalystbyZoho_List_All_Tables` then describes the schema.
 | MCP targets wrong environment | Zoho MCP defaults to Development | Switch environment explicitly in the Zoho MCP console if production is needed (use caution) |
 | `INVALID_INPUT: job_name must contain only alphanumeric and underscore` on `CatalystbyZoho_Create_Immediate_Job` | `job_name` contains hyphens or spaces | Use underscores only — `doc_audit_run_1` not `doc-audit-run-1` |
 | Job submission fails with missing field error | `jobpool_id` not provided to `CatalystbyZoho_Create_Immediate_Job` | Call `CatalystbyZoho_List_All_Jobpools` first; if none exist, call `CatalystbyZoho_Create_Job_Pool` then use the returned ID |
+| `INVALID_INPUT` on `CatalystbyZoho_Create_Cron_Job` with a job_name under 25 characters | `job_name` exceeds the **20-character** limit for Cron jobs — stricter than Immediate Job's alphanumeric-only rule | Shorten to ≤20 characters, e.g. `lantern_q_purge` not `lantern_quarantine_purge` |
+| `jobpool Name and Id cannot be null`, a timezone error, or `INTERNAL_SERVER_ERROR` on `Create_Cron_Job` | Used the legacy Cloud Scale "third-party URL cron" shape instead of the current Webhook schema | Clone the shape from an existing working webhook cron: `jobpool_id` (Webhook pool), `target_type: "Webhook"`, `url`, `request_method`, `request_body`, `job_detail` |
 


### PR DESCRIPTION
- Added catalyst-job-scheduling with runtime-verified guidance for job pools, jobs, all cron types, retries, webhooks, MCP, SDKs, and observability.
- Updated routing across Catalyst docs to point Job Scheduling questions to the new skill.
- Fixed key accuracy issues: time units are seconds, cron job_name is limited to 20 characters, retry behavior is correctly documented, and invalid SDK/API examples were removed or corrected.
- Added security warnings for plaintext headers/params in job/cron responses and documented the correct webhook payload.
- Switched Catalyst documentation links to lightweight index.md pages and llms.txt.
- Standardized heading style, emoji usage, and updated skill metadata versions.